### PR TITLE
Optional hydrogen filtering in runner.py

### DIFF
--- a/examples/B2AR_DMS_example/B2AR_config.toml
+++ b/examples/B2AR_DMS_example/B2AR_config.toml
@@ -5,6 +5,7 @@ membrane_protein = true
 
 # Structure parameters 
 membrane_thickness = 15
+remove_hydrogens = true
 
 # Mutagenesis data
 mutation_data_path = "examples/B2AR_DMS_example/B2AR_processed_scores.csv"

--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -4,6 +4,7 @@ from tempfile import NamedTemporaryFile
 
 from pathlib import Path
 import pandas as pd
+import numpy as np
 import tomli
 import warnings
 import logging
@@ -107,6 +108,16 @@ class Runner:
         else:
             pdb = PDBFile.read(config.pdb_path)
             arr = pdb.get_structure(model=1, extra_fields=["b_factor", "occupancy"])
+
+        # Remove hydrogens if configured
+        if config.remove_hydrogens:
+            logger.info("Removing hydrogen atoms")
+            # Filter out atoms whose names start with 'H' or 'D' (hydrogen/deuterium)
+            non_hydrogen_mask = np.array([
+                not (name.strip().startswith("H") or name.strip().startswith("D"))
+                for name in arr.atom_name
+            ], dtype=bool)
+            arr = arr[non_hydrogen_mask]
 
         # create context object
         logger.info("Creating context object")

--- a/src/structure/structure_context.py
+++ b/src/structure/structure_context.py
@@ -145,6 +145,8 @@ class Config(BaseModel):
         Whether the protein is a membrane protein (affects analysis methods).
     membrane_thickness : Optional[float]
         Half-thickness of membrane in Angstroms (default: 15).
+    remove_hydrogens : bool
+        Whether to remove hydrogen atoms from the structure (default: True).
     mutation_data_path : Optional[Path]
         Path to CSV file containing mutagenesis data.
     mutation_data_chain : Optional[str]
@@ -178,6 +180,7 @@ class Config(BaseModel):
 
     # structure parameters
     membrane_thickness: Optional[float] = 15
+    remove_hydrogens: bool = True
 
     # mutagenesis data
     mutation_data_path: Optional[Path] = None


### PR DESCRIPTION
Add an optional hydrogen removal step in `runner.py` controlled by a `remove_hydrogens` config flag, defaulting to `true`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2861806f-ea70-4e67-bbd6-c7a8a6dfc769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2861806f-ea70-4e67-bbd6-c7a8a6dfc769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

