### PR TITLE
Add distance-to-surface metric (relative SASA, default threshold 0.25)

### DIFF
--- a/src/metrics/structure.py
+++ b/src/metrics/structure.py
@@ -81,6 +81,68 @@ def calculate_sasa(context: Context) -> pd.DataFrame:
     return metadata_df
 
 
+# Reference (max) SASA per residue type, Tien et al. 2013 PLOS ONE empirical values (Å²)
+_REF_SASA = {
+    "ALA": 121.0, "ARG": 265.0, "ASN": 187.0, "ASP": 187.0, "CYS": 148.0,
+    "GLN": 214.0, "GLU": 214.0, "GLY": 97.0, "HIS": 216.0, "ILE": 195.0,
+    "LEU": 191.0, "LYS": 230.0, "MET": 203.0, "PHE": 228.0, "PRO": 154.0,
+    "SER": 143.0, "THR": 163.0, "TRP": 264.0, "TYR": 255.0, "VAL": 165.0,
+}
+
+
+@register_metric(name='distance_to_surface', provides=['distance_to_nearest_surface_residue'], tags={'structure'})
+def calculate_distance_to_surface(context: Context, sasa_threshold: float = 0.25) -> pd.DataFrame:
+    """
+    Calculate distance from each residue to the nearest surface residue.
+
+    Surface is defined as residues whose relative SASA exceeds sasa_threshold.
+    Relative SASA = (observed per-residue SASA) / (reference SASA for that residue type).
+    Distance is residue centroid to residue centroid.
+
+    Parameters
+    ----------
+    context : Context
+        Context object containing residue metadata and structural information.
+    sasa_threshold : float, optional
+        Minimum relative SASA for a residue to be considered surface. Default is 0.25.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with 'distance_to_nearest_surface_residue' along with residue metadata.
+    """
+    # Per-residue SASA (same setup as calculate_sasa): atom-wise SASA, then sum per residue
+    array = context.aa
+    atom_sasa = struc.sasa(array=array, vdw_radii="ProtOr")
+    res_sasa = struc.apply_residue_wise(array, atom_sasa, np.sum)
+
+    # Relative SASA = observed / reference; surface = residues with relative SASA above threshold
+    res_starts = struc.get_residue_starts(array)
+    res_names = array.res_name[res_starts]
+    ref = np.array([_REF_SASA.get(str(r).strip(), np.nan) for r in res_names], dtype=float)
+    relative_sasa = np.where(ref > 0, res_sasa / ref, np.nan)
+    is_surface = relative_sasa > sasa_threshold
+
+    # Residue centroids (mean x, y, z of atoms per residue) for distance calculations
+    cx = struc.apply_residue_wise(array, array.coord[:, 0], np.mean)
+    cy = struc.apply_residue_wise(array, array.coord[:, 1], np.mean)
+    cz = struc.apply_residue_wise(array, array.coord[:, 2], np.mean)
+    centroids = np.stack([cx, cy, cz], axis=1)
+
+    # Min centroid-to-centroid distance from each residue to any surface residue; nan if no surface
+    n_res = len(res_starts)
+    distances = np.full(n_res, np.nan, dtype=float)
+    surface_centroids = centroids[is_surface]
+    if surface_centroids.size > 0:
+        diff = centroids[:, None, :] - surface_centroids[None, :, :]
+        d2 = (diff ** 2).sum(axis=2)
+        distances = np.sqrt(np.min(d2, axis=1))
+
+    metadata_df = get_metadata_cols(array)
+    metadata_df['distance_to_nearest_surface_residue'] = distances
+    return metadata_df
+
+
 @register_metric(name='kyte_doolittle', provides=['kyte_doolittle'], tags={'structure'})
 def calculate_kyte_doolittle(context: Context) -> pd.DataFrame:
     """

--- a/tests/metrics/test_structure.py
+++ b/tests/metrics/test_structure.py
@@ -147,6 +147,44 @@ def test_calculate_sasa():
             assert np.all(non_nan_values >= 0), f"{col} values should be non-negative"
 
 
+def test_calculate_distance_to_surface():
+    """Distance to nearest surface residue with default sasa_threshold=0.25."""
+    aa_list = ['ALA', 'GLY', 'SER']
+    arr = _make_chain(aa_list=aa_list, chain_id='A', altloc='')
+    context = Context(array=arr)
+
+    result = metrics.calculate_distance_to_surface(context)
+
+    assert 'distance_to_nearest_surface_residue' in result.columns
+    res_starts = struc.get_residue_starts(arr)
+    assert len(result) == len(res_starts)
+
+    values = result['distance_to_nearest_surface_residue']
+    valid = values.dropna()
+    assert np.all(valid >= 0), "Distances should be non-negative"
+    # Either some residues are surface (distance 0) or none are (all nan)
+    assert (values == 0).any() or values.isna().all(), "Expect some surface residues or all nan"
+
+
+def test_calculate_distance_to_surface_threshold():
+    """Distance to surface depends on sasa_threshold."""
+    aa_list = ['ALA', 'GLY', 'SER', 'LEU']
+    arr = _make_chain(aa_list=aa_list, chain_id='A', altloc='')
+    context = Context(array=arr)
+
+    low = metrics.calculate_distance_to_surface(context, sasa_threshold=0.01)
+    high = metrics.calculate_distance_to_surface(context, sasa_threshold=0.99)
+
+    # Low threshold: more residues count as surface -> more zeros
+    n_zero_low = (low['distance_to_nearest_surface_residue'] == 0).sum()
+    n_zero_high = (high['distance_to_nearest_surface_residue'] == 0).sum()
+    assert n_zero_low >= n_zero_high, "Lower threshold should yield at least as many surface residues"
+
+    # High threshold: fewer surface residues, so distances tend to be larger or nan
+    high_vals = high['distance_to_nearest_surface_residue'].dropna()
+    assert np.all(high_vals >= 0), "Distances with high threshold should be non-negative"
+
+
 def test_KD_values():  
     # Create a chain with known hydrophobic and hydrophilic residues
     aa_list = ['ILE', 'VAL', 'ALA', 'ASP', 'GLU', 'LYS']


### PR DESCRIPTION
## Summary

Adds a new structure metric that reports, for each residue, the distance to the nearest **surface** residue. Surface is defined as residues whose **relative SASA** exceeds a configurable threshold (default 0.25). Relative SASA uses reference (max) SASA per residue type from Tien et al. 2013 PLOS ONE empirical values; distance is centroid-to-centroid.

## Changes

- **`src/metrics/structure.py`**
  - `_REF_SASA`: reference SASA dict (20 standard residues, Tien et al. 2013).
  - `calculate_distance_to_surface(context, sasa_threshold=0.25)`: registered metric providing `distance_to_nearest_surface_residue`. Reuses the same SASA setup as `calculate_sasa`; computes relative SASA, surface mask, residue centroids, and minimum distance to any surface residue. Inline comments explain each step.

- **`tests/metrics/test_structure.py`**
  - `test_calculate_distance_to_surface`: checks column, length, non-negative distances, and that either some residues are surface (distance 0) or none (all nan).
  - `test_calculate_distance_to_surface_threshold`: low vs high `sasa_threshold` (0.01 vs 0.99) and that lower threshold yields at least as many surface residues.