### PR TITLE
Create hierarchy for running metrics

### DIFF
--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -21,7 +21,7 @@ from typing import List, Optional, Dict, Any
 # import files containing metrics to register them in _REGISTRY
 import src.metrics.sequence
 import src.metrics.structure
-from src.metrics.registry import _REGISTRY
+from src.metrics.registry import _REGISTRY, metrics_with_tag
 from src.structure.secondary_structure import get_secondary_structure_annotations, define_membrane_secondary_structure, define_soluble_secondary_structure
 
 logger = logging.getLogger(__name__)
@@ -271,6 +271,7 @@ class Runner:
         """
         
         result_frames = []
+        
         for m in metrics:
             meta, func = _REGISTRY[m]
 
@@ -280,13 +281,14 @@ class Runner:
             result_frames.append(df)
         
         # merge features
+        logger.info("Merging features")
         features = self._merge_features(result_frames, mutations=mutations)
         features['name'] = self.context.config.name
         return features
     
     
     def run(self, metrics: List[str] = None) -> None:
-        """Compute specified metrics and return as a merged DataFrame.
+        """Compute features for the pipeline.
 
         Parameters
         ----------
@@ -294,33 +296,18 @@ class Runner:
             List of metric names to compute.
         """
 
+        # Run metrics
         if metrics is None:
             metrics = list(_REGISTRY.keys())
-
-        # filter unknown metrics
-        else:
-            metrics = [m for m in metrics if m in _REGISTRY]
-        # TODO: resolve dependencies
-        #order = _topological_order(metrics)
-        order = metrics.copy()
-        result_frames = []
-        for m in order:
-            meta, func = _REGISTRY[m]
-            
-            logger.info(f"Calculating metric: {m}")
-            df = func(self.context)
-
-            # ensure returned DataFrame has index aligned with ctx.res_keys (or positional)
-            result_frames.append(df)
-
-            # Optionally store in extras by name
-            self.context.extras[m] = df
-
-        # merge all results into one DataFrame
-        logger.info("Merging features")
+        
+        # Configure metrics based on presence of mutation data
         mutations = self.context.config.mutation_data_path is not None
-        self.features = self._merge_features(result_frames, mutations=mutations)
-        self.features['name'] = self.context.config.name
+        if not mutations:
+            exclude_metrics = metrics_with_tag('sequence')
+            metrics = [m for m in metrics if m not in exclude_metrics]
+        
+        # Run metrics
+        self.features = self.run_metrics(metrics=metrics, mutations=mutations)
 
 
     def _merge_features(self, dfs: List[pd.DataFrame], mutations) -> pd.DataFrame:

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -400,13 +400,32 @@ def test_runner_run_metric_no_mutations(tmp_path):
         mutation_data_path=None
     )
 
-    # run all metrics
-    returned_features = myrunner.run_metrics(metrics=['define_secondary_structure', 'sasa', 'kyte_doolittle'])
+    # run multiple metrics
+    returned_features = myrunner.run_metrics(metrics=['sasa', 'kyte_doolittle'])
 
     # Check that all residues are present and no 'resm' column
     assert len(returned_features) == len(myrunner.context.residue_table)
     assert 'resm' not in returned_features.columns.tolist()
 
+
+def test_runner_run(tmp_path):
+    pdb_id = '8smv'
+
+    myrunner = runner.Runner(
+        pdb_id=pdb_id,
+        name='test_run',
+        pdb_path=None,
+        membrane_protein=False,
+        mutation_data_path=None
+    )
+
+    # run multiple metrics
+    myrunner.run()
+    returned_features = myrunner.features
+
+    # Check that output has same length as residue table and more columns
+    assert len(returned_features) == len(myrunner.context.residue_table)
+    assert len(returned_features.columns) > len(myrunner.context.residue_table.columns)
 
 
 def test_runner__merge_features():


### PR DESCRIPTION
The current run function is designed to run all of the single residue metrics. With the open PRs that are going to define different classes of interactions (secondary structure, protein ligand, neighborhood, etc), this function will just be one part of the run pipeline. This PR creates a new, top-level run function that handles the setup, and calls the run_metrics function to run metrics. This overall run function can then be modified to run subsequent classes of features. 