### PR TITLE
Fix features row explosion from merge when residue_table has NA in mutation keys

### DIFF
--- a/src/metrics/sequence.py
+++ b/src/metrics/sequence.py
@@ -95,18 +95,28 @@ def calculate_effect_variance(context: Context) -> pd.DataFrame:
         DataFrame with 'effect_variance' and 'effect_variance_rank' along with residue metadata.
     """
     
-    # Calculate SEM for each position
-    seq_data = context.residue_table.loc[context.residue_table.mut_info, :]
-    effect_variance = seq_data.groupby('resi_mut')['effect'].sem().reset_index()
-    effect_variance.rename(columns={'effect': 'effect_variance'}, inplace=True)
+    # Calculate SEM for each position from rows that actually have mutation context.
+    seq_data = context.residue_table.loc[context.residue_table.mut_info, :].copy()
+    position_cols = ['chain', 'resi_mut', 'resn_mut']
+    effect_variance = (
+        seq_data
+        .groupby(position_cols, dropna=False)['effect']
+        .sem()
+        .reset_index(name='effect_variance')
+    )
     
     # Rank positions based on variance
     effect_variance['effect_variance_rank'] = effect_variance['effect_variance'].rank(method='min')
     effect_variance['effect_variance_rank'] = effect_variance['effect_variance_rank'] / np.max(effect_variance['effect_variance_rank'])
     
     # Add relevant metadata from original table
-    keep_cols = [col for col in KEEP_COLS if col in context.residue_table.columns]
-    effect_variance = pd.merge(context.residue_table[keep_cols], effect_variance, on='resi_mut', how='left')
+    keep_cols = [col for col in KEEP_COLS if col in seq_data.columns]
+    effect_variance = pd.merge(
+        seq_data[keep_cols],
+        effect_variance,
+        on=position_cols,
+        how='left'
+    )
     
     return effect_variance
 
@@ -366,7 +376,7 @@ def calculate_aa_groupings(context: Context) -> pd.DataFrame:
     # Extract residue table and subset to KEEP_COLS
     residue_table = context.residue_table
     keep_cols = [col for col in KEEP_COLS if col in residue_table.columns]
-    aa_groupings = residue_table[keep_cols].copy()
+    aa_groupings = residue_table.loc[residue_table.mut_info, keep_cols].copy()
     
     # Map wildtype amino acid to group
     aa_groupings['wildtype_aa_group'] = aa_groupings['resn_mut'].map(aa_to_group)

--- a/tests/pipeline/test_examples.py
+++ b/tests/pipeline/test_examples.py
@@ -15,6 +15,9 @@ def test_b2ar_example(tmp_path):
     runner.run()
     assert runner.features is not None
     assert {'packing_contact_density', 'sasa', 'blosum90'}.issubset(runner.features.columns)
+    assert len(runner.features) == len(runner.context.residue_table), (
+        "features must match residue_table length (no row explosion from merge)"
+    )
 
     output_dir = tmp_path / "b2ar_test_output"
     runner.save_results(output_dir=output_dir)


### PR DESCRIPTION
## Summary

When running the B2AR DMS example, the features DataFrame was expanding to 100k+ rows instead of the expected ~9k (matching residue_table length). This was caused by a many-to-many merge when sequence metrics returned rows with NA in merge keys (chain, resi_mut, resn_mut, resm).

## Root cause

Two sequence metrics were including struct-only rows (with NaN in resi_mut/resn_mut/resm):
- **effect_variance**: merged full residue_table with grouped SEM results; struct rows with (chain, NaN, NaN, NaN) matched many such rows in pandas merge (NaN matches NaN) → row explosion
- **aa_groupings**: returned full residue_table instead of only mut_info rows → same issue

## Changes

- **effect_variance**: Restrict to `mut_info` rows only; group by (chain, resi_mut, resn_mut); merge back to mutation rows only
- **aa_groupings**: Restrict to `residue_table.loc[mut_info, keep_cols]` instead of full table
- **test_examples.py**: Add assertion that `len(runner.features) == len(runner.context.residue_table)` to catch regression

## Testing

- `pytest tests/metrics/test_sequence.py` — 15 passed
- `pytest tests/pipeline/test_runner.py` — merge_features and run tests passed
- `pytest tests/pipeline/test_examples.py::test_b2ar_example` — passed
- Full suite: 128 passed

Made with [Cursor](https://cursor.com)