### PR TITLE
Fix membrane transform cache mismatch in runner

### DIFF
--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -528,6 +528,7 @@ class Runner:
                 pdbtm_df, tmatrix = pdbtm.fetch_pdbtm_annotation(self.context.config.pdb_id)
                 self.context.residue_table = pdbtm.add_pdbtm_regions(residue_table=self.context.residue_table, pdbtm_regions=pdbtm_df)
                 self.context.array.coord = pdbtm.transform_coordinates(self.context.array.coord, tmatrix)
+                self.context.aa = self.context.array[struc.filter_amino_acids(self.context.array)]
                 self.context.residue_table = define_membrane_secondary_structure(self.context.residue_table, ss_df)
             except RuntimeError as e:
                 raise RuntimeError(f"Failed to fetch PDBTM annotation for {self.context.config.pdb_id}: {e}. Rerun with membrane_protein=False to calculate soluble secondary structure.")

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -1169,3 +1169,4 @@ def test_calculate_protein_ligand_interactions(tmp_path):
     out_skip = runner.calculate_protein_ligand_interactions(myrunner.context, contacting_df)
     assert out_skip.shape[0] == myrunner.context.residue_table.shape[0]
     assert 'ligand_B_1_ALA_interactions' not in out_skip.columns
+


### PR DESCRIPTION
## Summary
- refresh `context.aa` after applying the PDBTM transform in `Runner.__post_init__`
- keep ligand interaction geometry based on `context.aa` while ensuring that cache is synchronized post-transform
- preserve existing runner test coverage while retaining requested test-file formatting updates

## Test plan
- [x] `pytest tests/pipeline/test_runner.py -k \"initialization_overrides_membrane or calculate_protein_ligand_interactions\"`

Made with [Cursor](https://cursor.com)