### PR TITLE
Test pip caching in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install DSSP
         run: |


### PR DESCRIPTION
## Summary
- add `cache: pip` and `cache-dependency-path: pyproject.toml` to `actions/setup-python`
- keep the change isolated so we can compare dependency setup times against the recent baseline run
- capture current local baseline for follow-up work: warm pip cache reduced `pip install -e \".[test]\"` from about 103s to 23s, while `tests/pipeline/test_examples.py::test_b2ar_example` stayed dominated by `Runner(...)` init and `runner.run()`

## Test plan
- [ ] confirm whether repeated CI runs show a cache hit and materially reduce the `Install dependencies` step
- [ ] compare `tests/pipeline/test_examples.py::test_b2ar_example` timing against prior runs to see whether the slowdown is install-related or pure test/runtime cost
- [ ] use the resulting logs to decide whether to prioritize `pydssp` packaging changes, test fixture/mocking changes, or both

Made with [Cursor](https://cursor.com)