### PR TITLE
Sort mutation wildtype by position before structure alignment

### DIFF
--- a/src/pipeline/sequence_alignment.py
+++ b/src/pipeline/sequence_alignment.py
@@ -356,8 +356,13 @@ def merge_mutation_scores(
     # Subset residue table to the specified chain
     residue_table_chain = residue_table[residue_table['chain'] == chain]
 
-    # Subset mutation scores to only the wildtype sequence
-    mutation_scores_subset = mutation_scores[['resi', 'resn']].drop_duplicates()
+    # Subset mutation scores to only the wildtype sequence (N-to-C order, not CSV row order)
+    mutation_scores_subset = (
+        mutation_scores[['resi', 'resn']]
+        .drop_duplicates()
+        .sort_values(['resi', 'resn'], kind='mergesort')
+        .reset_index(drop=True)
+    )
 
     # Prepare sequences for alignment, a single string of single-letter amino acids
     mut_seq_short = mutation_scores_subset['resn'].apply(lambda aa: convert_amino_acid(aa, force_convert=True))

--- a/tests/pipeline/test_sequence_alignment.py
+++ b/tests/pipeline/test_sequence_alignment.py
@@ -242,3 +242,46 @@ def test_merge_mutation_scores(tmp_path):
         assert merged_df['struct_info'].tolist() == [True, True, True, True, True, True, True, True]
         assert set(alignment_merged.columns) >= {'chain', 'resi_mut', 'resn_mut', 'resi_struct', 'resn_struct', 'align_pos'}
         assert len(alignment_merged) == 4
+
+
+def test_merge_mutation_scores_row_order_invariant():
+    """Shuffled mutation score rows must not permute the wildtype sequence used for alignment."""
+    mutation_scores_df = pd.DataFrame({
+        'resn': ['ARG', 'ARG', 'THR', 'THR', 'GLU', 'GLU', 'ASP'],
+        'resi': [12, 12, 13, 13, 14, 14, 15],
+        'resm': ['ALA', 'GLY', 'VAL', 'GLU', 'CYS', 'ASP', 'MET'],
+        'type': ['missense', 'missense', 'nonsense', 'missense', 'missense', 'nonsense', 'missense'],
+        'effect': [0.5, -1.2, 0.3, -0.7, 1.0, -0.4, -0.1],
+        'extra_col': [10, 20, 30, 40, 50, 60, 70],
+    })
+    residue_table = pd.DataFrame({
+        'chain': ['A', 'A', 'A', 'A', 'B'],
+        'resi': [1, 2, 3, 4, 1],
+        'resn': ['LEU', 'THR', 'GLU', 'ASP', 'TYR'],
+        'ss_group': ['TM1', 'TM1', 'TM1', 'TM1', 'TM1'],
+        'ss_domains': ['TM1_start', 'TM1_mid', 'TM1_mid', 'TM1_end', 'TM1_start'],
+    })
+
+    merged_ordered, align_ordered = merge_mutation_scores(
+        mutation_scores=mutation_scores_df,
+        residue_table=residue_table.copy(),
+        chain='A',
+        alignment_cutoff=0.7,
+    )
+
+    shuffled = mutation_scores_df.sample(frac=1, random_state=0).reset_index(drop=True)
+    merged_shuf, align_shuf = merge_mutation_scores(
+        mutation_scores=shuffled,
+        residue_table=residue_table.copy(),
+        chain='A',
+        alignment_cutoff=0.7,
+    )
+
+    cmp_align = ['resi_mut', 'resn_mut', 'resi_struct', 'resn_struct', 'align_pos']
+    pd.testing.assert_frame_equal(align_ordered[cmp_align], align_shuf[cmp_align])
+
+    sort_keys = ['align_pos', 'resi_mut', 'resn_mut', 'resm', 'type', 'effect']
+    pd.testing.assert_frame_equal(
+        merged_ordered.sort_values(sort_keys, kind='mergesort').reset_index(drop=True),
+        merged_shuf.sort_values(sort_keys, kind='mergesort').reset_index(drop=True),
+    )


### PR DESCRIPTION
## Goal

Mutation CSVs are often grouped or unsorted. `merge_mutation_scores` previously built the wildtype sequence from `drop_duplicates()` in **first-seen row order**, which could permute residues relative to true sequence position and misalign to the PDB.

## Implementation

- `src/pipeline/sequence_alignment.py`: After deduplicating `(resi, resn)`, sort by `resi` then `resn` with stable `mergesort`, reset index, then build `mut_seq`.
- `tests/pipeline/test_sequence_alignment.py`: `test_merge_mutation_scores_row_order_invariant` shuffles rows with a fixed RNG seed and asserts the same alignment mapping and merged residue table (after sorting comparable keys) as the ordered-input baseline.

## Other areas

None.

Made with [Cursor](https://cursor.com)