### PR TITLE
Reorder module functions to match usage flow

### DIFF
--- a/src/metrics/sequence.py
+++ b/src/metrics/sequence.py
@@ -16,6 +16,53 @@ logger = logging.getLogger(__name__)
 # columns to keep for sequence feature calculation to enable merging back to full table
 KEEP_COLS = ['chain', 'resi_mut', 'resn_mut', 'resm']
 
+
+def make_phat75_73():
+    """
+    Make Phat 75/73 substitution matrix.
+
+    Returns
+    -------
+    substitution_matrices.Array
+        Phat 75/73 substitution matrix.
+    """
+
+    PHAT_ALPHABET = "ARNDCQEGHILKMFPSTWYV"
+
+    # PHAT 75/73 scores (symmetric). Values transcribed from the PHAT paper figure.
+    _PHAT_LOWER_TRI = [
+    [  5],
+    [ -6,  9],
+    [ -2, -3, 11],
+    [ -5, -7,  2, 12],
+    [  1, -8, -2, -7,  7],
+    [ -3, -2,  2,  0, -5,  9],
+    [ -5, -6,  0,  6, -7,  1, 12],
+    [  1, -5, -1, -2, -2, -2, -3,  9],
+    [ -3, -4,  4, -1, -7,  2, -1, -4, 11],
+    [  0, -6, -3, -5, -3, -3, -5, -2, -5,  5],
+    [ -1, -6, -3, -5, -2, -3, -5, -2, -4,  2,  4],
+    [ -7, -1, -2, -5,-10, -1, -4, -5, -5, -7, -7,  5],
+    [ -1, -6, -2, -5, -2, -1, -5, -1, -4,  3,  2, -6,  6],
+    [ -1, -7, -1, -5,  0, -2, -5, -2, -2,  0,  1, -7,  0,  6],
+    [ -3, -7, -4, -5, -8, -3, -5, -3, -6, -4, -5, -4, -5, -5, 13],
+    [  2, -6,  1, -4,  1, -1, -3,  1, -2, -2, -2, -5, -2, -2, -3,  6],
+    [  0, -6, -1, -5, -1, -3, -5, -1, -4, -1, -1, -6,  0, -2, -4,  1,  3],
+    [ -4, -7, -5, -7, -4,  1, -7, -5, -3, -4, -3, -8, -4,  0, -6, -5, -7, 11],
+    [ -3, -6,  2, -4, -1,  0, -2, -3,  3, -3, -2, -4, -2,  4, -5, -2, -3,  1, 11],
+    [  1, -7, -3, -5, -2, -3, -5, -2, -5,  3,  1, -8,  1, -1, -4, -2,  0, -4, -3,  4],
+    ]
+
+    n = len(PHAT_ALPHABET)
+    mat = np.zeros((n, n), dtype=int)
+    # fill lower triangle + diagonal
+    for i, row in enumerate(_PHAT_LOWER_TRI):
+        mat[i, :i+1] = row
+    # symmetrize
+    mat = mat + mat.T - np.diag(np.diag(mat))
+
+    return substitution_matrices.Array(alphabet=PHAT_ALPHABET, data=mat)
+
 @register_metric(name='position_effect_quartiles', provides=['effect_quartile', 'pos_effect'],
                  requires={'resm'}, tags={'sequence'})
 def calculate_position_effect_quartiles(context: Context, percentiles: Optional[List[float]] = None) -> pd.DataFrame:
@@ -260,53 +307,6 @@ def calculate_blosum_score(context: Context) -> pd.DataFrame:
     blosum_scores[f'blosum{blosum_threshold}'] = blosum_scores.apply(get_blosum_score, axis=1)
 
     return blosum_scores
-
-
-def make_phat75_73():
-    """
-    Make Phat 75/73 substitution matrix.
-
-    Returns
-    -------
-    substitution_matrices.Array
-        Phat 75/73 substitution matrix.
-    """
-
-    PHAT_ALPHABET = "ARNDCQEGHILKMFPSTWYV"
-
-    # PHAT 75/73 scores (symmetric). Values transcribed from the PHAT paper figure.
-    _PHAT_LOWER_TRI = [
-    [  5],
-    [ -6,  9],
-    [ -2, -3, 11],
-    [ -5, -7,  2, 12],
-    [  1, -8, -2, -7,  7],
-    [ -3, -2,  2,  0, -5,  9],
-    [ -5, -6,  0,  6, -7,  1, 12],
-    [  1, -5, -1, -2, -2, -2, -3,  9],
-    [ -3, -4,  4, -1, -7,  2, -1, -4, 11],
-    [  0, -6, -3, -5, -3, -3, -5, -2, -5,  5],
-    [ -1, -6, -3, -5, -2, -3, -5, -2, -4,  2,  4],
-    [ -7, -1, -2, -5,-10, -1, -4, -5, -5, -7, -7,  5],
-    [ -1, -6, -2, -5, -2, -1, -5, -1, -4,  3,  2, -6,  6],
-    [ -1, -7, -1, -5,  0, -2, -5, -2, -2,  0,  1, -7,  0,  6],
-    [ -3, -7, -4, -5, -8, -3, -5, -3, -6, -4, -5, -4, -5, -5, 13],
-    [  2, -6,  1, -4,  1, -1, -3,  1, -2, -2, -2, -5, -2, -2, -3,  6],
-    [  0, -6, -1, -5, -1, -3, -5, -1, -4, -1, -1, -6,  0, -2, -4,  1,  3],
-    [ -4, -7, -5, -7, -4,  1, -7, -5, -3, -4, -3, -8, -4,  0, -6, -5, -7, 11],
-    [ -3, -6,  2, -4, -1,  0, -2, -3,  3, -3, -2, -4, -2,  4, -5, -2, -3,  1, 11],
-    [  1, -7, -3, -5, -2, -3, -5, -2, -5,  3,  1, -8,  1, -1, -4, -2,  0, -4, -3,  4],
-    ]
-
-    n = len(PHAT_ALPHABET)
-    mat = np.zeros((n, n), dtype=int)
-    # fill lower triangle + diagonal
-    for i, row in enumerate(_PHAT_LOWER_TRI):
-        mat[i, :i+1] = row
-    # symmetrize
-    mat = mat + mat.T - np.diag(np.diag(mat))
-
-    return substitution_matrices.Array(alphabet=PHAT_ALPHABET, data=mat)
 
 
 @register_metric(name='phat_score', provides=['phat_score'], requires={'resm'}, tags={'sequence'})

--- a/src/metrics/structure.py
+++ b/src/metrics/structure.py
@@ -19,6 +19,31 @@ from src.structure.utils import get_metadata_cols, is_backbone_atom, is_heavy, r
 
 logger = logging.getLogger(__name__)
 
+# Reference (max) SASA per residue type, Tien et al. 2013 PLOS ONE empirical values (Å²)
+_REF_SASA = {
+    "ALA": 121.0, "ARG": 265.0, "ASN": 187.0, "ASP": 187.0, "CYS": 148.0,
+    "GLN": 214.0, "GLU": 214.0, "GLY": 97.0, "HIS": 216.0, "ILE": 195.0,
+    "LEU": 191.0, "LYS": 230.0, "MET": 203.0, "PHE": 228.0, "PRO": 154.0,
+    "SER": 143.0, "THR": 163.0, "TRP": 264.0, "TYR": 255.0, "VAL": 165.0,
+}
+
+DSSP_METRIC_COLUMNS = [
+    "dssp_acc",
+    "dssp_nh_o_1_relidx",
+    "dssp_nh_o_1_energy",
+    "dssp_o_nh_1_relidx",
+    "dssp_o_nh_1_energy",
+    "dssp_nh_o_2_relidx",
+    "dssp_nh_o_2_energy",
+    "dssp_o_nh_2_relidx",
+    "dssp_o_nh_2_energy",
+    "dssp_tco",
+    "dssp_kappa",
+    "dssp_alpha",
+    "dssp_phi",
+    "dssp_psi",
+]
+
 
 @register_metric(name='sasa', provides=['sasa', 'sasa_backbone', 'sasa_sidechain', 'sasa_polar', 'sasa_nonpolar'], tags={'structure'})
 def calculate_sasa(context: Context) -> pd.DataFrame:
@@ -86,15 +111,6 @@ def calculate_sasa(context: Context) -> pd.DataFrame:
     metadata_df['sasa_nonpolar'] = res_sasa_nonpolar
     
     return metadata_df
-
-
-# Reference (max) SASA per residue type, Tien et al. 2013 PLOS ONE empirical values (Å²)
-_REF_SASA = {
-    "ALA": 121.0, "ARG": 265.0, "ASN": 187.0, "ASP": 187.0, "CYS": 148.0,
-    "GLN": 214.0, "GLU": 214.0, "GLY": 97.0, "HIS": 216.0, "ILE": 195.0,
-    "LEU": 191.0, "LYS": 230.0, "MET": 203.0, "PHE": 228.0, "PRO": 154.0,
-    "SER": 143.0, "THR": 163.0, "TRP": 264.0, "TYR": 255.0, "VAL": 165.0,
-}
 
 
 @register_metric(name='distance_to_surface', provides=['distance_to_nearest_surface_residue'], tags={'structure'})
@@ -233,6 +249,8 @@ def calculate_membrane_distance(context: Context) -> pd.DataFrame:
     metadata_df['distance_from_membrane_edge'] = distance_from_edge
 
     return metadata_df
+
+
 @register_metric(name='calculate_packing_metrics', provides=['packing_n_atoms', 'packing_n_neighbor_residues', 'packing_contact_density'], tags={'structure', 'interaction'})
 def calculate_residue_packing(context: Context, cutoff: float = 5.0) -> pd.DataFrame:
     """
@@ -383,24 +401,6 @@ def calculate_center_of_mass_distance(context: Context) -> pd.DataFrame:
     metadata_df['distance_to_center_of_mass'] = distances
     
     return metadata_df
-
-
-DSSP_METRIC_COLUMNS = [
-    "dssp_acc",
-    "dssp_nh_o_1_relidx",
-    "dssp_nh_o_1_energy",
-    "dssp_o_nh_1_relidx",
-    "dssp_o_nh_1_energy",
-    "dssp_nh_o_2_relidx",
-    "dssp_nh_o_2_energy",
-    "dssp_o_nh_2_relidx",
-    "dssp_o_nh_2_energy",
-    "dssp_tco",
-    "dssp_kappa",
-    "dssp_alpha",
-    "dssp_phi",
-    "dssp_psi",
-]
 
 
 @register_metric(name="dssp_metrics", provides=DSSP_METRIC_COLUMNS, tags={"structure", "dssp"})

--- a/src/pipeline/ligands.py
+++ b/src/pipeline/ligands.py
@@ -30,6 +30,11 @@ KNOWN_LIGANDS = frozenset({
 })
 
 
+def _sanitize_column_name(value: str) -> str:
+    """Normalize ligand-derived strings for safe column names."""
+    return str(value).strip().replace(" ", "_")
+
+
 def format_ligand_id(chain: str, res_id: int, res_name: str) -> str:
     """Build a canonical ligand identifier for joins against partner residue keys."""
     res_name_str = "" if res_name is None else str(res_name).strip()
@@ -94,11 +99,6 @@ def find_ligands(
                 )
 
     return result
-
-
-def _sanitize_column_name(value: str) -> str:
-    """Normalize ligand-derived strings for safe column names."""
-    return str(value).strip().replace(" ", "_")
 
 
 def calculate_protein_ligand_interactions(

--- a/src/pipeline/neighbors.py
+++ b/src/pipeline/neighbors.py
@@ -9,21 +9,6 @@ from src.pipeline.context import Context
 from src.structure.utils import is_heavy, res_key
 
 
-def calculate_neighborhood_features(
-    context: Context,
-    features: pd.DataFrame,
-) -> pd.DataFrame:
-    """Run registered neighborhood metric functions and merge their outputs."""
-    merge_cols = ["chain", "resi_struct", "resn_struct"]
-    base = features[merge_cols].drop_duplicates().reset_index(drop=True)
-
-    for func in NEIGHBORHOOD_METRIC_FUNCTIONS:
-        df = func(context, features)
-        base = pd.merge(base, df, on=merge_cols, how="left")
-
-    return base
-
-
 def compute_residue_neighbors(
     context: Context,
     cutoff: float,
@@ -81,3 +66,18 @@ def compute_residue_neighbors(
 
     context.extras["residue_neighbors"] = mapping
     return mapping
+
+
+def calculate_neighborhood_features(
+    context: Context,
+    features: pd.DataFrame,
+) -> pd.DataFrame:
+    """Run registered neighborhood metric functions and merge their outputs."""
+    merge_cols = ["chain", "resi_struct", "resn_struct"]
+    base = features[merge_cols].drop_duplicates().reset_index(drop=True)
+
+    for func in NEIGHBORHOOD_METRIC_FUNCTIONS:
+        df = func(context, features)
+        base = pd.merge(base, df, on=merge_cols, how="left")
+
+    return base

--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -285,6 +285,64 @@ class Runner:
         return Config(**base_dict)
 
 
+    def _merge_features(self, dfs: List[pd.DataFrame], mutations) -> pd.DataFrame:
+        """Merge feature DataFrames on chain and appropriate resi/resn/resm columns.
+
+        Parameters
+        ----------
+        dfs : List[pd.DataFrame]
+            List of DataFrames to merge.
+
+        mutations : bool
+            Whether mutation-level data is included (i.e., resm column present).
+
+        Returns
+        -------
+        pd.DataFrame
+            Merged DataFrame.
+        """
+        # Get all unique rows to merge on
+
+        potential_cols = ['chain', 'resi_struct', 'resn_struct', 'resi_mut', 'resn_mut', 'align_pos']
+        keep_cols = [col for col in potential_cols if col in self.context.residue_table.columns]
+
+        # Add mutation columns if mutations are present
+        keep_cols += ['resm'] if mutations else []
+
+        merged_df = self.context.residue_table[keep_cols].drop_duplicates().reset_index(drop=True)
+
+        # Filter merged_df to only include structural_feature_chains if specified
+        # This ensures the final output only contains the specified chains, even though
+        # residue_table itself is not filtered (filtering happens in individual metrics)
+        if self.context.config.structural_feature_chains is not None:
+            merged_df = merged_df[
+                merged_df['chain'].isin(self.context.config.structural_feature_chains)
+            ].reset_index(drop=True)
+
+        for df in dfs:
+            # Determine merge columns based on what's available in the df
+            merge_cols = ['chain']
+
+            # Check if this is a sequence-based or structure-based metric
+            if 'resi_mut' in df.columns:
+                merge_cols.extend(['resi_mut', 'resn_mut'])
+                if 'resm' in df.columns:
+                    merge_cols.append('resm')
+            elif 'resi_struct' in df.columns:
+                merge_cols.extend(['resi_struct', 'resn_struct'])
+
+            merged_df = pd.merge(merged_df, df, on=merge_cols, how='left')
+
+        # Sort using the same logic as residue_table
+        mutation_chain = self.context.config.mutation_data_chain if mutations else None
+        merged_df = _sort_residue_table(merged_df, mutation_chain=mutation_chain)
+
+        # Drop align_pos before returning (it's just for internal sorting)
+        merged_df = merged_df.drop(columns=['align_pos'])
+
+        return merged_df
+
+
     def run_metrics(self, metrics: List[str], mutations: bool = False) -> pd.DataFrame:
         """Compute specified metrics and return as a merged DataFrame.
 
@@ -396,64 +454,6 @@ class Runner:
                 how='left',
                 validate='many_to_one',
             )
-
-
-    def _merge_features(self, dfs: List[pd.DataFrame], mutations) -> pd.DataFrame:
-        """Merge feature DataFrames on chain and appropriate resi/resn/resm columns.
-
-        Parameters
-        ----------
-        dfs : List[pd.DataFrame]
-            List of DataFrames to merge.
-
-        mutations : bool
-            Whether mutation-level data is included (i.e., resm column present).
-
-        Returns
-        -------
-        pd.DataFrame
-            Merged DataFrame.
-        """
-        # Get all unique rows to merge on
-
-        potential_cols = ['chain', 'resi_struct', 'resn_struct', 'resi_mut', 'resn_mut', 'align_pos']
-        keep_cols = [col for col in potential_cols if col in self.context.residue_table.columns]
-        
-        # Add mutation columns if mutations are present
-        keep_cols += ['resm'] if mutations else []
-        
-        merged_df = self.context.residue_table[keep_cols].drop_duplicates().reset_index(drop=True)
-
-        # Filter merged_df to only include structural_feature_chains if specified
-        # This ensures the final output only contains the specified chains, even though
-        # residue_table itself is not filtered (filtering happens in individual metrics)
-        if self.context.config.structural_feature_chains is not None:
-            merged_df = merged_df[
-                merged_df['chain'].isin(self.context.config.structural_feature_chains)
-            ].reset_index(drop=True)
-
-        for df in dfs:
-            # Determine merge columns based on what's available in the df
-            merge_cols = ['chain']
-            
-            # Check if this is a sequence-based or structure-based metric
-            if 'resi_mut' in df.columns:
-                merge_cols.extend(['resi_mut', 'resn_mut'])
-                if 'resm' in df.columns:
-                    merge_cols.append('resm')
-            elif 'resi_struct' in df.columns:
-                merge_cols.extend(['resi_struct', 'resn_struct'])
-            
-            merged_df = pd.merge(merged_df, df, on=merge_cols, how='left')
-
-        # Sort using the same logic as residue_table
-        mutation_chain = self.context.config.mutation_data_chain if mutations else None
-        merged_df = _sort_residue_table(merged_df, mutation_chain=mutation_chain)
-        
-        # Drop align_pos before returning (it's just for internal sorting)
-        merged_df = merged_df.drop(columns=['align_pos'])
-        
-        return merged_df
 
     def run_neighborhood(
         self,

--- a/src/structure/secondary_structure.py
+++ b/src/structure/secondary_structure.py
@@ -13,6 +13,37 @@ from src.pipeline.context import Context
 from src.structure.utils import get_metadata_cols
 
 
+def make_contiguous_group_labels(lst: List[str]) -> List[str]:
+    """
+    Given a list of values, return a new list where contiguous identical values
+    are labeled with a suffix indicating their group number.
+
+    Parameters
+    ----------
+
+    lst : List[str]
+        Input list of values.
+
+    Returns
+    -------
+
+    result : List[str]
+        List with contiguous group labels.
+    """
+    result = []
+    counters = {}
+
+    # Group by contiguous identical values
+    for val, group in groupby(lst):
+        counters[val] = counters.get(val, 0) + 1
+
+        # Create label with group number
+        label = f"{val}_{counters[val]}"
+        result.extend([label] * len(list(group)))
+
+    return result
+
+
 def get_secondary_structure_annotations(context: Context) -> pd.DataFrame:
     """
     Get secondary structure annotations for an atom array.
@@ -209,38 +240,6 @@ def _annotate_with_pydssp(context: Context) -> pd.DataFrame:
 
     keys_df["sse"] = labels
     return keys_df[["chain", "resi", "sse"]]
-
-
-
-def make_contiguous_group_labels(lst: List[str]) -> List[str]:
-    """
-    Given a list of values, return a new list where contiguous identical values
-    are labeled with a suffix indicating their group number.
-
-    Parameters
-    ----------
-
-    lst : List[str]
-        Input list of values.
-
-    Returns
-    -------
-
-    result : List[str]
-        List with contiguous group labels.
-    """
-    result = []
-    counters = {}
-
-    # Group by contiguous identical values
-    for val, group in groupby(lst):
-        counters[val] = counters.get(val, 0) + 1
-
-        # Create label with group number
-        label = f"{val}_{counters[val]}"
-        result.extend([label] * len(list(group)))
-
-    return result
 
 
 def define_membrane_secondary_structure(residue_table: pd.DataFrame, ss_df: pd.DataFrame) -> pd.DataFrame:

--- a/src/structure/utils.py
+++ b/src/structure/utils.py
@@ -15,29 +15,6 @@ import biotite.structure as struc
 import numpy as np
 import pandas as pd
 
-
-def get_metadata_cols(array: struc.AtomArray) -> pd.DataFrame:
-    """
-    Extract metadata columns (chain, resi_struct, resn_struct) from an AtomArray.
-
-    Parameters
-    ----------
-    array : struc.AtomArray
-        Biotite AtomArray containing protein structure data.
-
-    Returns
-    -------
-    pd.DataFrame
-
-    """
-    res_starts = struc.get_residue_starts(array)
-    chains = array.chain_id[res_starts]
-    resi = array.res_id[res_starts]
-    resn = array.res_name[res_starts]
-        
-    return pd.DataFrame({"chain": chains, "resi_struct": resi, "resn_struct": resn})
-
-
 #________________HYDROGEN BONDS__________________________
 
 DA_MAX = 3.5           # Å donor–acceptor distance
@@ -61,6 +38,28 @@ AcceptorSite = namedtuple(
     "AcceptorSite",
     "res_key resname chain resi atom_name altloc coord is_backbone",
 )
+
+
+def get_metadata_cols(array: struc.AtomArray) -> pd.DataFrame:
+    """
+    Extract metadata columns (chain, resi_struct, resn_struct) from an AtomArray.
+
+    Parameters
+    ----------
+    array : struc.AtomArray
+        Biotite AtomArray containing protein structure data.
+
+    Returns
+    -------
+    pd.DataFrame
+
+    """
+    res_starts = struc.get_residue_starts(array)
+    chains = array.chain_id[res_starts]
+    resi = array.res_id[res_starts]
+    resn = array.res_name[res_starts]
+
+    return pd.DataFrame({"chain": chains, "resi_struct": resi, "resn_struct": resn})
 
 
 def _norm_vec(v: np.ndarray) -> np.ndarray:
@@ -112,6 +111,25 @@ def is_backbone_atom(atom_name: str) -> bool:
         True if the atom is a backbone atom, False otherwise.
     """
     return atom_name in ("N", "CA", "C", "O", "OXT", "H", "H1", "H2", "H3")
+
+
+def is_heavy(atom_name: str) -> bool:
+    """
+    Check if an atom is a heavy atom (non-hydrogen).
+
+    Parameters
+    ----------
+    atom_name : str
+        Name of the atom.
+
+    Returns
+    -------
+    bool
+        True if the atom is heavy (does not start with 'H' or 'D'),
+        False otherwise.
+    """
+    n = atom_name.strip()
+    return not (n.startswith("H") or n.startswith("D"))
 
 
 def norm_alt(a: Any) -> str:
@@ -527,24 +545,5 @@ def detect_hbonds(
                 }
             )
     return hbonds
-
-#_________________________________PACKING_________________________
-def is_heavy(atom_name: str) -> bool:
-    """
-    Check if an atom is a heavy atom (non-hydrogen).
-
-    Parameters
-    ----------
-    atom_name : str
-        Name of the atom.
-
-    Returns
-    -------
-    bool
-        True if the atom is heavy (does not start with 'H' or 'D'),
-        False otherwise.
-    """
-    n = atom_name.strip()
-    return not (n.startswith("H") or n.startswith("D"))
 
 

--- a/tests/metrics/test_bonds.py
+++ b/tests/metrics/test_bonds.py
@@ -9,42 +9,6 @@ from src.structure.utils import res_key
 from tests.test_utils import _make_atoms, _make_chain, _make_residue
 
 
-def test_identify_salt_bridges():
-    """Test salt bridge identification with ASP-LYS pairs."""
-    # Create ASP and LYS residues close together
-    # ASP: N, CA, C, O, CB, CG, OD1, OD2 (8 atoms)
-    asp_coords = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0],
-                  [1.5, 1.0, 0.0], [1.5, 1.5, 0.0], [5.0, 0.0, 0.0], [1.5, 1.5, -0.5]]  # CB, CG, OD1, OD2
-    # LYS: N, CA, C, O, CB, CG, CD, CE, NZ (9 atoms)
-    lys_coords = [[10.0, 0.0, 0.0], [11.0, 0.0, 0.0], [12.0, 0.0, 0.0], [13.0, 0.0, 0.0],
-                  [11.5, 1.0, 0.0], [11.5, 2.0, 0.0], [11.5, 3.0, 0.0], [11.5, 4.0, 0.0],
-                  [5.0, 0.0, 3.5]]  # CB, CG, CD, CE, NZ (3.5 A away from OD1)
-    
-    asp = _make_residue('ASP', res_id=1, chain_id='A', coords=asp_coords)
-    lys = _make_residue('LYS', res_id=3, chain_id='A', coords=lys_coords)
-    arr = struc.concatenate([asp, lys])
-    
-    result = bonds.identify_salt_bridges(arr, cutoff=4.0)
-    
-    assert len(result) == 2
-    
-    # Check that expected residues are found
-    assert result.iloc[0]['chain'] == 'A'
-    assert result.iloc[0]['resi_struct'] == 1
-    assert result.iloc[0]['resn_struct'] == 'ASP'
-    assert result.iloc[0]['partner_chain'] == 'A'
-    assert result.iloc[0]['partner_resi'] == 3
-    assert result.iloc[0]['partner_resn'] == 'LYS'
-    assert result.iloc[0]['bond_type'] == 'salt_bridge'
-    assert result.iloc[1]['chain'] == 'A'
-    assert result.iloc[1]['resi_struct'] == 3
-    assert result.iloc[1]['resn_struct'] == 'LYS'
-    assert result.iloc[1]['partner_chain'] == 'A'
-    assert result.iloc[1]['partner_resi'] == 1
-    assert result.iloc[1]['partner_resn'] == 'ASP'
-    assert result.iloc[1]['bond_type'] == 'salt_bridge'
-
-
 def test_classify_bond_types():
     """Classify bond types correctly flags protein/protein vs protein/ligand."""
     ala = _make_residue('ALA', res_id=1, chain_id='A')
@@ -81,6 +45,42 @@ def test_identify_hbonds():
         assert len(parts) == 2
         assert parts[0] in ('backbone', 'sidechain')
         assert parts[1] in ('backbone', 'sidechain')
+
+
+def test_identify_salt_bridges():
+    """Test salt bridge identification with ASP-LYS pairs."""
+    # Create ASP and LYS residues close together
+    # ASP: N, CA, C, O, CB, CG, OD1, OD2 (8 atoms)
+    asp_coords = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0],
+                  [1.5, 1.0, 0.0], [1.5, 1.5, 0.0], [5.0, 0.0, 0.0], [1.5, 1.5, -0.5]]  # CB, CG, OD1, OD2
+    # LYS: N, CA, C, O, CB, CG, CD, CE, NZ (9 atoms)
+    lys_coords = [[10.0, 0.0, 0.0], [11.0, 0.0, 0.0], [12.0, 0.0, 0.0], [13.0, 0.0, 0.0],
+                  [11.5, 1.0, 0.0], [11.5, 2.0, 0.0], [11.5, 3.0, 0.0], [11.5, 4.0, 0.0],
+                  [5.0, 0.0, 3.5]]  # CB, CG, CD, CE, NZ (3.5 A away from OD1)
+
+    asp = _make_residue('ASP', res_id=1, chain_id='A', coords=asp_coords)
+    lys = _make_residue('LYS', res_id=3, chain_id='A', coords=lys_coords)
+    arr = struc.concatenate([asp, lys])
+
+    result = bonds.identify_salt_bridges(arr, cutoff=4.0)
+
+    assert len(result) == 2
+
+    # Check that expected residues are found
+    assert result.iloc[0]['chain'] == 'A'
+    assert result.iloc[0]['resi_struct'] == 1
+    assert result.iloc[0]['resn_struct'] == 'ASP'
+    assert result.iloc[0]['partner_chain'] == 'A'
+    assert result.iloc[0]['partner_resi'] == 3
+    assert result.iloc[0]['partner_resn'] == 'LYS'
+    assert result.iloc[0]['bond_type'] == 'salt_bridge'
+    assert result.iloc[1]['chain'] == 'A'
+    assert result.iloc[1]['resi_struct'] == 3
+    assert result.iloc[1]['resn_struct'] == 'LYS'
+    assert result.iloc[1]['partner_chain'] == 'A'
+    assert result.iloc[1]['partner_resi'] == 1
+    assert result.iloc[1]['partner_resn'] == 'ASP'
+    assert result.iloc[1]['bond_type'] == 'salt_bridge'
 
 
 def test_calculate_salt_bridges():

--- a/tests/metrics/test_sequence.py
+++ b/tests/metrics/test_sequence.py
@@ -100,6 +100,22 @@ def test_calculate_position_effect_quartiles_custom_percentiles():
     assert custom_q1_count > default_q1_count
 
 
+def test_calculate_position_effect_quartiles_multichain_error():
+    """Test that ValueError is raised when residue table contains data from more than one chain."""
+    # Create test residue table with multiple chains
+    residue_table = _make_residue_table(num_residues=5, num_chains=2, make_muts=True)
+
+    class MockContext:
+        def __init__(self, residue_table):
+            self.residue_table = residue_table
+
+    context = MockContext(residue_table)
+
+    # Verify that ValueError is raised with appropriate message
+    with pytest.raises(ValueError, match="calculate_position_effect_quartiles only supports single chain mutation data"):
+        metrics.calculate_position_effect_quartiles(context)
+
+
 def test_calculate_effect_variance():
     # create test residue table
     residue_table = _make_residue_table(num_residues=100, num_chains=1, make_muts=True)
@@ -342,94 +358,6 @@ def test_calculate_blosum_score():
         assert blosum_df.at[idx, 'blosum90'] == expected_score
 
 
-def test_calculate_position_effect_quartiles_multichain_error():
-    """Test that ValueError is raised when residue table contains data from more than one chain."""
-    # Create test residue table with multiple chains
-    residue_table = _make_residue_table(num_residues=5, num_chains=2, make_muts=True)
-    
-    class MockContext:
-        def __init__(self, residue_table):
-            self.residue_table = residue_table
-    
-    context = MockContext(residue_table)
-    
-    # Verify that ValueError is raised with appropriate message
-    with pytest.raises(ValueError, match="calculate_position_effect_quartiles only supports single chain mutation data"):
-        metrics.calculate_position_effect_quartiles(context)
-
-
-def test_calculate_aa_groupings_with_muts():
-    """Test amino acid groupings with mutations."""
-    # Define expected groups for verification
-    aa_groups = {
-        "Nonpolar_Aliphatic": ["ALA", "VAL", "LEU", "ILE", "MET"],
-        "Aromatic": ["PHE", "TRP", "TYR"],
-        "Polar_Uncharged": ["SER", "THR", "ASN", "GLN", "CYS"],
-        "Positively_Charged": ["LYS", "ARG", "HIS"],
-        "Negatively_Charged": ["ASP", "GLU"],
-        "Special": ["PRO", "GLY"]
-    }
-    
-    # Create reverse mapping for verification
-    aa_to_group = {}
-    for group_name, aa_list in aa_groups.items():
-        for aa in aa_list:
-            aa_to_group[aa] = group_name
-    
-    # create test residue table with mutations
-    residue_table = _make_residue_table(num_residues=5, num_chains=1, make_muts=True)
-    
-    class MockContext:
-        def __init__(self, residue_table):
-            self.residue_table = residue_table
-    
-    context = MockContext(residue_table)
-    
-    # calculate aa groupings
-    aa_groupings_df = metrics.calculate_aa_groupings(context)
-    
-    # check that all three output columns exist
-    assert 'wildtype_aa_group' in aa_groupings_df.columns
-    assert 'mut_aa_group' in aa_groupings_df.columns
-    assert 'wildtype_mut_aa_group' in aa_groupings_df.columns
-    
-    # verify that values are correctly assigned
-    for idx, row in aa_groupings_df.iterrows():
-        expected_wt_group = aa_to_group.get(row['resn_mut'], np.nan)
-        expected_mut_group = aa_to_group.get(row['resm'], np.nan)
-        
-        assert aa_groupings_df.at[idx, 'wildtype_aa_group'] == expected_wt_group
-        assert aa_groupings_df.at[idx, 'mut_aa_group'] == expected_mut_group
-
-        expected_concatenated = f"{expected_wt_group}_{expected_mut_group}"
-        assert aa_groupings_df.at[idx, 'wildtype_mut_aa_group'] == expected_concatenated
-
-
-def test_calculate_aa_groupings_no_muts():
-    """Test amino acid groupings without mutations."""
-    # create test residue table without mutations
-    residue_table = _make_residue_table(num_residues=5, num_chains=1, make_muts=False)
-    
-    class MockContext:
-        def __init__(self, residue_table):
-            self.residue_table = residue_table
-    
-    context = MockContext(residue_table)
-    
-    # calculate aa groupings
-    aa_groupings_df = metrics.calculate_aa_groupings(context)
-    
-    # check that wildtype_aa_group column exists
-    assert 'wildtype_aa_group' in aa_groupings_df.columns
-    
-    # check that mut columns do not exist when resm is missing
-    # Note: The function should still create mut columns if resm is in KEEP_COLS but empty
-    # But if resm column doesn't exist at all, the columns shouldn't be created
-    if 'resm' not in residue_table.columns:
-        assert 'mut_aa_group' not in aa_groupings_df.columns
-        assert 'wildtype_mut_aa_group' not in aa_groupings_df.columns
-
-
 def test_make_phat75_73():
     """Test that make_phat75_73 returns Phat 75/73 substitution matrix."""
     phat75_73 = metrics.make_phat75_73()
@@ -458,3 +386,75 @@ def test_calculate_phat_score():
     context = MockContext(residue_table)
     phat_df = metrics.calculate_phat_score(context)
     assert phat_df['phat_score'].iloc[0] == np.inf
+
+
+def test_calculate_aa_groupings_with_muts():
+    """Test amino acid groupings with mutations."""
+    # Define expected groups for verification
+    aa_groups = {
+        "Nonpolar_Aliphatic": ["ALA", "VAL", "LEU", "ILE", "MET"],
+        "Aromatic": ["PHE", "TRP", "TYR"],
+        "Polar_Uncharged": ["SER", "THR", "ASN", "GLN", "CYS"],
+        "Positively_Charged": ["LYS", "ARG", "HIS"],
+        "Negatively_Charged": ["ASP", "GLU"],
+        "Special": ["PRO", "GLY"]
+    }
+
+    # Create reverse mapping for verification
+    aa_to_group = {}
+    for group_name, aa_list in aa_groups.items():
+        for aa in aa_list:
+            aa_to_group[aa] = group_name
+
+    # create test residue table with mutations
+    residue_table = _make_residue_table(num_residues=5, num_chains=1, make_muts=True)
+
+    class MockContext:
+        def __init__(self, residue_table):
+            self.residue_table = residue_table
+
+    context = MockContext(residue_table)
+
+    # calculate aa groupings
+    aa_groupings_df = metrics.calculate_aa_groupings(context)
+
+    # check that all three output columns exist
+    assert 'wildtype_aa_group' in aa_groupings_df.columns
+    assert 'mut_aa_group' in aa_groupings_df.columns
+    assert 'wildtype_mut_aa_group' in aa_groupings_df.columns
+
+    # verify that values are correctly assigned
+    for idx, row in aa_groupings_df.iterrows():
+        expected_wt_group = aa_to_group.get(row['resn_mut'], np.nan)
+        expected_mut_group = aa_to_group.get(row['resm'], np.nan)
+
+        assert aa_groupings_df.at[idx, 'wildtype_aa_group'] == expected_wt_group
+        assert aa_groupings_df.at[idx, 'mut_aa_group'] == expected_mut_group
+
+        expected_concatenated = f"{expected_wt_group}_{expected_mut_group}"
+        assert aa_groupings_df.at[idx, 'wildtype_mut_aa_group'] == expected_concatenated
+
+
+def test_calculate_aa_groupings_no_muts():
+    """Test amino acid groupings without mutations."""
+    # create test residue table without mutations
+    residue_table = _make_residue_table(num_residues=5, num_chains=1, make_muts=False)
+
+    class MockContext:
+        def __init__(self, residue_table):
+            self.residue_table = residue_table
+
+    context = MockContext(residue_table)
+
+    # calculate aa groupings
+    aa_groupings_df = metrics.calculate_aa_groupings(context)
+
+    # check that wildtype_aa_group column exists
+    assert 'wildtype_aa_group' in aa_groupings_df.columns
+
+    # check that mut columns do not exist when resm is missing
+    # Note: The function should still create mut columns if resm is in KEEP_COLS but empty
+    # But if resm column doesn't exist at all, the columns shouldn't be created
+    if 'resm' not in residue_table.columns:
+        assert 'mut_aa_group' not in aa_groupings_df.columns
+        assert 'wildtype_mut_aa_group' not in aa_groupings_df.columns

--- a/tests/metrics/test_structure.py
+++ b/tests/metrics/test_structure.py
@@ -96,28 +96,6 @@ ATOM   2537 HD22 LEU A 169     -22.200 -37.598  -0.114  1.00 27.94           H
 ATOM   2538 HD23 LEU A 169     -22.842 -39.045   0.017  1.00 27.94           H"""
 
 
-def test_calculate_membrane_distance():
-    # Create a test chain with varying z-coordinates
-    z_values = list(range(-25, 25, 5))
-    coords = [[np.random.randint(10), np.random.randint(10), z] for z in z_values]
-    aa_list = random.choices(AA_LIST, k=len(z_values))
-    arr = _make_chain(aa_list=aa_list, coords=coords, chain_id='A', altloc='')
-
-    class MockContext:
-        def __init__(self, array):
-            self.array = array
-            self.config = Config()
-
-    context = MockContext(array=arr)
-
-    distances = metrics.calculate_membrane_distance(context)
-
-    # Expected distance is absolute z minus membrane thickness
-    expected_distances = np.abs(np.array(z_values)) - 15.0
-
-    assert np.allclose(distances['distance_from_membrane_edge'], expected_distances)
-
-
 ##TO DO MAKE MORE ROBUST WITH REAL PDB FILE
 def test_calculate_sasa():  
     # Create a simple chain with a few residues
@@ -225,6 +203,28 @@ def test_KD_values():
     assert kd_values.iloc[0] > 4.0, "ILE should be highly hydrophobic"
     assert kd_values.iloc[3] < -3.0, "ASP should be hydrophilic"
     assert kd_values.iloc[4] < -3.0, "GLU should be hydrophilic"
+
+
+def test_calculate_membrane_distance():
+    # Create a test chain with varying z-coordinates
+    z_values = list(range(-25, 25, 5))
+    coords = [[np.random.randint(10), np.random.randint(10), z] for z in z_values]
+    aa_list = random.choices(AA_LIST, k=len(z_values))
+    arr = _make_chain(aa_list=aa_list, coords=coords, chain_id='A', altloc='')
+
+    class MockContext:
+        def __init__(self, array):
+            self.array = array
+            self.config = Config()
+
+    context = MockContext(array=arr)
+
+    distances = metrics.calculate_membrane_distance(context)
+
+    # Expected distance is absolute z minus membrane thickness
+    expected_distances = np.abs(np.array(z_values)) - 15.0
+
+    assert np.allclose(distances['distance_from_membrane_edge'], expected_distances)
 
 
 ##TO DO MAKE MORE ROBUST WITH REAL PDB FILE

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -23,6 +23,40 @@ np.random.seed(42)
 random.seed(42)
 
 
+def test_sort_residue_table():
+    """Test that _sort_residue_table works correctly."""
+    # Test 1: Sorting with mutation_chain specified
+    df_with_mutation = pd.DataFrame({
+        'chain': ['C', 'B', 'A', 'B', 'A', 'C'],
+        'align_pos': [2, 0, 1, 3, 4, 5],
+        'resi_mut': [1, 2, 3, 4, 5, 6],
+        'resn_mut': ['ALA', 'GLY', 'SER', 'THR', 'VAL', 'LEU']
+    })
+
+    sorted_df = runner._sort_residue_table(df_with_mutation, mutation_chain='B')
+
+    # Check that chain B comes first
+    chains = sorted_df['chain'].tolist()
+    assert chains[0] == 'B' and chains[1] == 'B', "Mutation chain B should come first"
+
+    # Check that within each chain, residues are sorted by align_pos
+    chain_b_align_pos = sorted_df[sorted_df['chain'] == 'B']['align_pos'].tolist()
+    assert chain_b_align_pos == sorted(chain_b_align_pos), "Within chain B, should be sorted by align_pos"
+
+    # Check that other chains are alphabetically ordered
+    assert chains == ['B', 'B', 'A', 'A', 'C', 'C'], "Should be B first, then A, then C"
+
+    # Test 2: Sorting without mutation_chain (alphabetical)
+    sorted_df_alpha = runner._sort_residue_table(df_with_mutation, mutation_chain=None)
+    chains_alpha = sorted_df_alpha['chain'].tolist()
+    assert chains_alpha == ['A', 'A', 'B', 'B', 'C', 'C'], "Should be alphabetically sorted when no mutation_chain"
+
+    # Check sorting within each chain
+    for chain in ['A', 'B', 'C']:
+        chain_align_pos = sorted_df_alpha[sorted_df_alpha['chain'] == chain]['align_pos'].tolist()
+        assert chain_align_pos == sorted(chain_align_pos), f"Within chain {chain}, should be sorted by align_pos"
+
+
 def test_runner_initialization_from_config(tmp_path):
 
     config_path = tmp_path / 'config.toml'
@@ -334,6 +368,159 @@ def test_runner__merge_config(tmp_path):
 
 
 
+def test_runner__merge_features():
+    pdb_id = '8smv'
+
+    myrunner = runner.Runner(
+        pdb_id=pdb_id,
+        name='test_merge_features',
+        pdb_path=None,
+        membrane_protein=False,
+        mutation_data_path=None
+    )
+
+    residue_table = _make_residue_table(num_residues=6, num_chains=2, start_resis=[1,8], make_muts=False)
+
+    # df1 has residue level features from a subset of the residues
+    df1_keep_resis = np.random.choice(residue_table['resi_struct'], size=7, replace=False)
+    df1 = residue_table[residue_table['resi_struct'].isin(df1_keep_resis)].copy()
+    df1 = df1[['chain', 'resi_struct', 'resn_struct']]
+    df1['feature1'] = np.random.rand(len(df1))
+
+    # df2 has residue-level features from a subset of positions in chain A
+    df2_keep_resis = np.random.choice(residue_table[residue_table['chain']=='A']['resi_struct'], size=3, replace=False)
+    df2 = residue_table[(residue_table['chain']=='A') & (residue_table['resi_struct'].isin(df2_keep_resis))].copy()
+    df2 = df2[['chain', 'resi_struct', 'resn_struct']]
+    df2['feature2'] = np.random.rand(len(df2))
+
+    # df3 has residue level features from residues in Chain B
+    df3_keep_resis = np.random.choice(residue_table.loc[residue_table['chain']=='B']['resi_struct'],
+                                      size=5, replace=False)
+    df3 = residue_table[residue_table['resi_struct'].isin(df3_keep_resis)].copy()
+    df3 = df3[['chain', 'resi_struct', 'resn_struct']]
+    df3['feature3'] = np.random.rand(len(df3))
+
+    result_frames = [df1, df2, df3]
+
+    class MockConfig:
+        structural_feature_chains = None
+
+    class MockContext:
+        def __init__(self, residue_table):
+            self.residue_table = residue_table
+            self.config = MockConfig()
+    myrunner.context = MockContext(residue_table=residue_table)
+
+    merged_df = myrunner._merge_features(result_frames, mutations=False)
+
+    assert 'resm' not in merged_df.columns.tolist()
+    assert len(merged_df) == len(residue_table)
+
+    # Check that df values are correctly merged
+    df1_mask = merged_df['resi_struct'].isin(df1_keep_resis)
+    assert not merged_df.loc[df1_mask, 'feature1'].isnull().all()
+    assert merged_df.loc[~df1_mask, 'feature1'].isnull().all()
+
+    df2_mask = (merged_df['chain']=='A') & (merged_df['resi_struct'].isin(df2_keep_resis))
+    assert not merged_df.loc[df2_mask, 'feature2'].isnull().all()
+    assert merged_df.loc[~df2_mask, 'feature2'].isnull().all()
+
+    df3_mask = merged_df['resi_struct'].isin(df3_keep_resis)
+    assert not merged_df.loc[df3_mask, 'feature3'].isnull().all()
+    assert merged_df.loc[~df3_mask, 'feature3'].isnull().all()
+
+
+def test_runner__merge_features_with_muts():
+    pdb_id = '8smv'
+
+    myrunner = runner.Runner(
+        pdb_id=pdb_id,
+        name='test_merge_features_with_muts',
+        pdb_path=None,
+        membrane_protein=False,
+        mutation_data_path=None
+    )
+
+    residue_table = _make_residue_table(num_residues=6, num_chains=2, start_resis=[1,8], make_muts=[True, False])
+    residue_table_no_muts = residue_table[['chain', 'resi_struct', 'resn_struct', 'resi_mut', 'resn_mut']].drop_duplicates().reset_index(drop=True)
+
+    # df1 has residue level features from a subset of the residues
+    df1_keep_resis = np.random.choice(residue_table_no_muts['resi_struct'], size=7, replace=False)
+    df1 = residue_table_no_muts[residue_table_no_muts['resi_struct'].isin(df1_keep_resis)].copy()
+    df1 = df1[['chain', 'resi_struct', 'resn_struct']]
+    df1['feature1'] = np.random.rand(len(df1))
+
+    # df2 has mutation-level features for all mutations from a subset of positions in chain A
+    df2_keep_resis = np.random.choice(residue_table[residue_table['chain']=='A']['resi_mut'], size=3, replace=False)
+    df2 = residue_table[(residue_table['chain']=='A') & (residue_table['resi_mut'].isin(df2_keep_resis))].copy()
+    df2 = df2[['chain', 'resi_mut', 'resn_mut', 'resm']]
+    df2['feature2'] = np.random.rand(len(df2))
+
+    # df3 has residue level features from residues in Chain B
+    df3_keep_resis = np.random.choice(residue_table_no_muts.loc[residue_table_no_muts['chain']=='B']['resi_struct'],
+                                      size=5, replace=False)
+    df3 = residue_table_no_muts[residue_table_no_muts['resi_struct'].isin(df3_keep_resis)].copy()
+    df3 = df3[['chain', 'resi_struct', 'resn_struct']]
+    df3['feature3'] = np.random.rand(len(df3))
+
+    # df4 has a subset of mutations at each position
+    df4_keep_resis = np.random.choice(len(residue_table), size=40, replace=False)
+    df4 = residue_table.iloc[df4_keep_resis].copy()
+    df4 = df4[['chain', 'resi_mut', 'resn_mut', 'resm']]
+    df4['feature4'] = np.random.rand(len(df4))
+
+    result_frames = [df1, df2, df3, df4]
+
+    class MockConfig:
+        def __init__(self):
+            self.mutation_data_chain = 'A'
+            self.structural_feature_chains = None
+
+    class MockContext:
+        def __init__(self, residue_table):
+            self.residue_table = residue_table
+            self.config = MockConfig()
+
+    myrunner.context = MockContext(residue_table=residue_table)
+
+    merged_df = myrunner._merge_features(result_frames, mutations=True)
+
+    assert len(merged_df) == len(residue_table)
+    assert 'resm' in merged_df.columns.tolist()
+
+    # Check that df values are correctly merged for structure-based features
+    df1_mask = merged_df['resi_struct'].isin(df1_keep_resis)
+    assert not merged_df.loc[df1_mask, 'feature1'].isnull().all()
+    assert merged_df.loc[~df1_mask, 'feature1'].isnull().all()
+
+    # Check sequence-based features
+    df2_mask = (merged_df['chain']=='A') & (merged_df['resi_mut'].isin(df2_keep_resis))
+    assert not merged_df.loc[df2_mask, 'feature2'].isnull().all()
+    assert merged_df.loc[~df2_mask, 'feature2'].isnull().all()
+
+    df3_mask = merged_df['resi_struct'].isin(df3_keep_resis)
+    assert not merged_df.loc[df3_mask, 'feature3'].isnull().all()
+    assert merged_df.loc[~df3_mask, 'feature3'].isnull().all()
+
+    df4 = df4.set_index(['chain', 'resi_mut', 'resn_mut', 'resm'])
+    merged_df = merged_df.set_index(['chain', 'resi_mut', 'resn_mut', 'resm'])
+    df4_mask = merged_df.index.isin(df4.index)
+    assert not merged_df.loc[df4_mask, 'feature4'].isnull().all()
+    assert merged_df.loc[~df4_mask,  'feature4'].isnull().all()
+
+    # Reset index for sorting checks
+    merged_df = merged_df.reset_index()
+
+    # Check that output is sorted appropriately (chains in order)
+    chains = merged_df['chain'].tolist()
+    unique_chains = []
+    for c in chains:
+        if not unique_chains or unique_chains[-1] != c:
+            unique_chains.append(c)
+    # Should be alphabetically sorted since no mutation_chain
+    assert unique_chains == sorted(unique_chains), "Chains should be alphabetically sorted"
+
+
 def test_runner_run_metric(tmp_path):
     # Create a mock mutation dataset
     residue_table = _make_residue_table(
@@ -487,157 +674,40 @@ def test_runner_run(tmp_path):
     assert returned_features[all_graph_cols].notna().any().any(), "graph_all_* columns are all null."
 
 
-def test_runner__merge_features():
-    pdb_id = '8smv'
+def test_run_neighborhood_requires_run_first(tmp_path):
+    """run_neighborhood must be called after run(); it raises if self.features is missing."""
+    config_path = tmp_path / 'config.toml'
+    _make_config_file(config_path)
 
-    myrunner = runner.Runner(
-        pdb_id=pdb_id,
-        name='test_merge_features',
-        pdb_path=None,
-        membrane_protein=False,
-        mutation_data_path=None
-    )
-
-    residue_table = _make_residue_table(num_residues=6, num_chains=2, start_resis=[1,8], make_muts=False)
-
-    # df1 has residue level features from a subset of the residues
-    df1_keep_resis = np.random.choice(residue_table['resi_struct'], size=7, replace=False)
-    df1 = residue_table[residue_table['resi_struct'].isin(df1_keep_resis)].copy()
-    df1 = df1[['chain', 'resi_struct', 'resn_struct']]
-    df1['feature1'] = np.random.rand(len(df1))
-
-    # df2 has residue-level features from a subset of positions in chain A
-    df2_keep_resis = np.random.choice(residue_table[residue_table['chain']=='A']['resi_struct'], size=3, replace=False)
-    df2 = residue_table[(residue_table['chain']=='A') & (residue_table['resi_struct'].isin(df2_keep_resis))].copy()
-    df2 = df2[['chain', 'resi_struct', 'resn_struct']]
-    df2['feature2'] = np.random.rand(len(df2))
-
-    # df3 has residue level features from residues in Chain B
-    df3_keep_resis = np.random.choice(residue_table.loc[residue_table['chain']=='B']['resi_struct'],
-                                      size=5, replace=False)
-    df3 = residue_table[residue_table['resi_struct'].isin(df3_keep_resis)].copy()
-    df3 = df3[['chain', 'resi_struct', 'resn_struct']]
-    df3['feature3'] = np.random.rand(len(df3))
-
-    result_frames = [df1, df2, df3]
-
-    class MockConfig:
-        structural_feature_chains = None
-
-    class MockContext:
-        def __init__(self, residue_table):
-            self.residue_table = residue_table
-            self.config = MockConfig()
-    myrunner.context = MockContext(residue_table=residue_table)
-
-    merged_df = myrunner._merge_features(result_frames, mutations=False)
-
-    assert 'resm' not in merged_df.columns.tolist()
-    assert len(merged_df) == len(residue_table)
-
-    # Check that df values are correctly merged
-    df1_mask = merged_df['resi_struct'].isin(df1_keep_resis)
-    assert not merged_df.loc[df1_mask, 'feature1'].isnull().all()
-    assert merged_df.loc[~df1_mask, 'feature1'].isnull().all()
-
-    df2_mask = (merged_df['chain']=='A') & (merged_df['resi_struct'].isin(df2_keep_resis))
-    assert not merged_df.loc[df2_mask, 'feature2'].isnull().all()
-    assert merged_df.loc[~df2_mask, 'feature2'].isnull().all()
-
-    df3_mask = merged_df['resi_struct'].isin(df3_keep_resis)
-    assert not merged_df.loc[df3_mask, 'feature3'].isnull().all()
-    assert merged_df.loc[~df3_mask, 'feature3'].isnull().all()
+    base_runner = runner.Runner(config_path=config_path)
+    with pytest.raises(ValueError, match="No features to extend"):
+        base_runner.run_neighborhood(cutoff=10.0)
 
 
-def test_runner__merge_features_with_muts():
-    pdb_id = '8smv'
+def test_run_neighborhood_fills_extras_and_merges(tmp_path):
+    """run_neighborhood fills context.extras['residue_neighbors'] and merges n_ala_neighbors into self.features."""
+    config_path = tmp_path / 'config.toml'
+    _make_config_file(config_path)
 
-    myrunner = runner.Runner(
-        pdb_id=pdb_id,
-        name='test_merge_features_with_muts',
-        pdb_path=None,
-        membrane_protein=False,
-        mutation_data_path=None
-    )
+    myrunner = runner.Runner(config_path=config_path)
+    myrunner.features = myrunner.run_metrics(metrics=['sasa', 'kyte_doolittle'])
 
-    residue_table = _make_residue_table(num_residues=6, num_chains=2, start_resis=[1,8], make_muts=[True, False])
-    residue_table_no_muts = residue_table[['chain', 'resi_struct', 'resn_struct', 'resi_mut', 'resn_mut']].drop_duplicates().reset_index(drop=True)
+    myrunner.run_neighborhood(cutoff=10.0)
 
-    # df1 has residue level features from a subset of the residues  
-    df1_keep_resis = np.random.choice(residue_table_no_muts['resi_struct'], size=7, replace=False)
-    df1 = residue_table_no_muts[residue_table_no_muts['resi_struct'].isin(df1_keep_resis)].copy()
-    df1 = df1[['chain', 'resi_struct', 'resn_struct']]
-    df1['feature1'] = np.random.rand(len(df1))
+    # Extras filled with residue_key -> [residue_key, ...]; no self-neighbors
+    mapping = myrunner.context.extras['residue_neighbors']
+    assert isinstance(mapping, dict)
+    for residue_key, neighbors in mapping.items():
+        assert isinstance(residue_key, str)
+        assert ":" in residue_key
+        assert isinstance(neighbors, list)
+        assert residue_key not in neighbors, "neighbors must not include self"
 
-    # df2 has mutation-level features for all mutations from a subset of positions in chain A
-    df2_keep_resis = np.random.choice(residue_table[residue_table['chain']=='A']['resi_mut'], size=3, replace=False)
-    df2 = residue_table[(residue_table['chain']=='A') & (residue_table['resi_mut'].isin(df2_keep_resis))].copy()
-    df2 = df2[['chain', 'resi_mut', 'resn_mut', 'resm']]
-    df2['feature2'] = np.random.rand(len(df2))
-
-    # df3 has residue level features from residues in Chain B
-    df3_keep_resis = np.random.choice(residue_table_no_muts.loc[residue_table_no_muts['chain']=='B']['resi_struct'],
-                                      size=5, replace=False)
-    df3 = residue_table_no_muts[residue_table_no_muts['resi_struct'].isin(df3_keep_resis)].copy()
-    df3 = df3[['chain', 'resi_struct', 'resn_struct']]
-    df3['feature3'] = np.random.rand(len(df3))
-
-    # df4 has a subset of mutations at each position
-    df4_keep_resis = np.random.choice(len(residue_table), size=40, replace=False)
-    df4 = residue_table.iloc[df4_keep_resis].copy()
-    df4 = df4[['chain', 'resi_mut', 'resn_mut', 'resm']]
-    df4['feature4'] = np.random.rand(len(df4))
-
-    result_frames = [df1, df2, df3, df4]
-
-    class MockConfig:
-        def __init__(self):
-            self.mutation_data_chain = 'A'
-            self.structural_feature_chains = None
-
-    class MockContext:
-        def __init__(self, residue_table):
-            self.residue_table = residue_table
-            self.config = MockConfig()
-
-    myrunner.context = MockContext(residue_table=residue_table)
-
-    merged_df = myrunner._merge_features(result_frames, mutations=True)
-
-    assert len(merged_df) == len(residue_table)
-    assert 'resm' in merged_df.columns.tolist()
-
-    # Check that df values are correctly merged for structure-based features
-    df1_mask = merged_df['resi_struct'].isin(df1_keep_resis)
-    assert not merged_df.loc[df1_mask, 'feature1'].isnull().all()
-    assert merged_df.loc[~df1_mask, 'feature1'].isnull().all()
-
-    # Check sequence-based features
-    df2_mask = (merged_df['chain']=='A') & (merged_df['resi_mut'].isin(df2_keep_resis))
-    assert not merged_df.loc[df2_mask, 'feature2'].isnull().all()
-    assert merged_df.loc[~df2_mask, 'feature2'].isnull().all()
-
-    df3_mask = merged_df['resi_struct'].isin(df3_keep_resis)
-    assert not merged_df.loc[df3_mask, 'feature3'].isnull().all()
-    assert merged_df.loc[~df3_mask, 'feature3'].isnull().all()
-
-    df4 = df4.set_index(['chain', 'resi_mut', 'resn_mut', 'resm'])
-    merged_df = merged_df.set_index(['chain', 'resi_mut', 'resn_mut', 'resm'])
-    df4_mask = merged_df.index.isin(df4.index)
-    assert not merged_df.loc[df4_mask, 'feature4'].isnull().all()
-    assert merged_df.loc[~df4_mask,  'feature4'].isnull().all()
-    
-    # Reset index for sorting checks
-    merged_df = merged_df.reset_index()
-    
-    # Check that output is sorted appropriately (chains in order)
-    chains = merged_df['chain'].tolist()
-    unique_chains = []
-    for c in chains:
-        if not unique_chains or unique_chains[-1] != c:
-            unique_chains.append(c)
-    # Should be alphabetically sorted since no mutation_chain
-    assert unique_chains == sorted(unique_chains), "Chains should be alphabetically sorted"
+    # n_ala_neighbors from count_ala_neighbors is merged into self.features
+    assert 'n_ala_neighbors' in myrunner.features.columns
+    assert 'neighborhood_sasa' in myrunner.features.columns
+    assert 'neighborhood_kyte_doolittle' in myrunner.features.columns
+    assert myrunner.features['n_ala_neighbors'].shape[0] == myrunner.features.shape[0]
 
 
 def test_runner_save_results(tmp_path):
@@ -737,76 +807,6 @@ def test_runner_save_results(tmp_path):
     metadata_path = output_dir_in_config / f"{pdb_id}_metadata.csv"
     assert features_path.exists()
     assert metadata_path.exists()
-
-
-def test_sort_residue_table():
-    """Test that _sort_residue_table works correctly."""
-    # Test 1: Sorting with mutation_chain specified
-    df_with_mutation = pd.DataFrame({
-        'chain': ['C', 'B', 'A', 'B', 'A', 'C'],
-        'align_pos': [2, 0, 1, 3, 4, 5],
-        'resi_mut': [1, 2, 3, 4, 5, 6],
-        'resn_mut': ['ALA', 'GLY', 'SER', 'THR', 'VAL', 'LEU']
-    })
-    
-    sorted_df = runner._sort_residue_table(df_with_mutation, mutation_chain='B')
-    
-    # Check that chain B comes first
-    chains = sorted_df['chain'].tolist()
-    assert chains[0] == 'B' and chains[1] == 'B', "Mutation chain B should come first"
-    
-    # Check that within each chain, residues are sorted by align_pos
-    chain_b_align_pos = sorted_df[sorted_df['chain'] == 'B']['align_pos'].tolist()
-    assert chain_b_align_pos == sorted(chain_b_align_pos), "Within chain B, should be sorted by align_pos"
-    
-    # Check that other chains are alphabetically ordered
-    assert chains == ['B', 'B', 'A', 'A', 'C', 'C'], "Should be B first, then A, then C"
-    
-    # Test 2: Sorting without mutation_chain (alphabetical)
-    sorted_df_alpha = runner._sort_residue_table(df_with_mutation, mutation_chain=None)
-    chains_alpha = sorted_df_alpha['chain'].tolist()
-    assert chains_alpha == ['A', 'A', 'B', 'B', 'C', 'C'], "Should be alphabetically sorted when no mutation_chain"
-    
-    # Check sorting within each chain
-    for chain in ['A', 'B', 'C']:
-        chain_align_pos = sorted_df_alpha[sorted_df_alpha['chain'] == chain]['align_pos'].tolist()
-        assert chain_align_pos == sorted(chain_align_pos), f"Within chain {chain}, should be sorted by align_pos"
-
-
-def test_run_neighborhood_requires_run_first(tmp_path):
-    """run_neighborhood must be called after run(); it raises if self.features is missing."""
-    config_path = tmp_path / 'config.toml'
-    _make_config_file(config_path)
-
-    base_runner = runner.Runner(config_path=config_path)
-    with pytest.raises(ValueError, match="No features to extend"):
-        base_runner.run_neighborhood(cutoff=10.0)
-
-
-def test_run_neighborhood_fills_extras_and_merges(tmp_path):
-    """run_neighborhood fills context.extras['residue_neighbors'] and merges n_ala_neighbors into self.features."""
-    config_path = tmp_path / 'config.toml'
-    _make_config_file(config_path)
-
-    myrunner = runner.Runner(config_path=config_path)
-    myrunner.features = myrunner.run_metrics(metrics=['sasa', 'kyte_doolittle'])
-
-    myrunner.run_neighborhood(cutoff=10.0)
-
-    # Extras filled with residue_key -> [residue_key, ...]; no self-neighbors
-    mapping = myrunner.context.extras['residue_neighbors']
-    assert isinstance(mapping, dict)
-    for residue_key, neighbors in mapping.items():
-        assert isinstance(residue_key, str)
-        assert ":" in residue_key
-        assert isinstance(neighbors, list)
-        assert residue_key not in neighbors, "neighbors must not include self"
-
-    # n_ala_neighbors from count_ala_neighbors is merged into self.features
-    assert 'n_ala_neighbors' in myrunner.features.columns
-    assert 'neighborhood_sasa' in myrunner.features.columns
-    assert 'neighborhood_kyte_doolittle' in myrunner.features.columns
-    assert myrunner.features['n_ala_neighbors'].shape[0] == myrunner.features.shape[0]
 
 
 def test_structural_feature_chains_validation(tmp_path):

--- a/tests/structure/test_secondary_structure.py
+++ b/tests/structure/test_secondary_structure.py
@@ -15,6 +15,15 @@ np.random.seed(42)
 import random
 
 
+def test_make_contiguous_group_labels():
+    input = ['A', 'A', 'B', 'B', 'A', 'A', 'A', 'C', 'C', 'B']
+    expected_output = ['A_1', 'A_1', 'B_1', 'B_1', 'A_2', 'A_2', 'A_2', 'C_1', 'C_1', 'B_2']
+
+    output = make_contiguous_group_labels(input)
+
+    assert output == expected_output
+
+
 def test_get_secondary_structure_annotations():
     aa_list = random.choices(AA_LIST, k=10)
     arr = _make_chain(aa_list=aa_list, chain_id='A')
@@ -78,15 +87,6 @@ def test_get_secondary_structure_annotations_unknown_backend():
     context.extras["ss_backend"] = "not_a_backend"
     with pytest.raises(ValueError, match="Unknown secondary-structure backend"):
         get_secondary_structure_annotations(context)
-
-
-def test_make_contiguous_group_labels():
-    input = ['A', 'A', 'B', 'B', 'A', 'A', 'A', 'C', 'C', 'B']
-    expected_output = ['A_1', 'A_1', 'B_1', 'B_1', 'A_2', 'A_2', 'A_2', 'C_1', 'C_1', 'B_2']
-
-    output = make_contiguous_group_labels(input)
-
-    assert output == expected_output
 
 
 def test_define_membrane_secondary_structure():

--- a/tests/structure/test_utils.py
+++ b/tests/structure/test_utils.py
@@ -4,27 +4,24 @@ from src.structure import utils
 from tests.test_utils import _make_chain, _make_residue
 
 
-def test_is_heavy():
-    # Test heavy atoms
-    assert utils.is_heavy("C") == True
-    assert utils.is_heavy("CA") == True
-    assert utils.is_heavy("N") == True
-    assert utils.is_heavy("O") == True
-    
-    # Test hydrogen atoms (should return False)
-    assert utils.is_heavy("H") == False
-    assert utils.is_heavy("HA") == False
-    assert utils.is_heavy("H1") == False
-    assert utils.is_heavy("HG") == False
-    assert utils.is_heavy("HD1") == False
-    
-    # Test deuterium
-    assert utils.is_heavy("D") == False
-    assert utils.is_heavy("DA") == False
-    
-    # Test edge cases
-    assert utils.is_heavy("  C  ") == True  # with whitespace
-    assert utils.is_heavy("  H  ") == False  # with whitespace
+def test_get_metadata_cols():
+    """Test that get_metadata_cols extracts correct metadata including altloc."""
+    # Create a chain with altloc identifiers
+    aa_list = ['ALA', 'CYS', 'ASP']
+    arr = _make_chain(aa_list=aa_list, chain_id='A', altloc='')
+
+    metadata_df = utils.get_metadata_cols(arr)
+
+    # Check that all expected columns are present
+    assert 'chain' in metadata_df.columns
+    assert 'resi_struct' in metadata_df.columns
+    assert 'resn_struct' in metadata_df.columns
+
+    # Check values
+    assert len(metadata_df) == 3
+    assert list(metadata_df['resn_struct']) == ['ALA', 'CYS', 'ASP']
+    assert list(metadata_df['resi_struct']) == [1, 2, 3]
+    assert all(metadata_df['chain'] == 'A')
 
 
 def test_res_key():
@@ -55,6 +52,29 @@ def test_is_backbone_atom():
     assert utils.is_backbone_atom("CG") == False
     assert utils.is_backbone_atom("NZ") == False
     assert utils.is_backbone_atom("OD1") == False
+
+
+def test_is_heavy():
+    # Test heavy atoms
+    assert utils.is_heavy("C") == True
+    assert utils.is_heavy("CA") == True
+    assert utils.is_heavy("N") == True
+    assert utils.is_heavy("O") == True
+
+    # Test hydrogen atoms (should return False)
+    assert utils.is_heavy("H") == False
+    assert utils.is_heavy("HA") == False
+    assert utils.is_heavy("H1") == False
+    assert utils.is_heavy("HG") == False
+    assert utils.is_heavy("HD1") == False
+
+    # Test deuterium
+    assert utils.is_heavy("D") == False
+    assert utils.is_heavy("DA") == False
+
+    # Test edge cases
+    assert utils.is_heavy("  C  ") == True  # with whitespace
+    assert utils.is_heavy("  H  ") == False  # with whitespace
 
 
 def test_norm_alt():
@@ -204,26 +224,6 @@ def test_detect_hbonds_parameters():
     
     # Lenient should find at least as many as strict
     assert len(hbonds_lenient) >= len(hbonds_strict)
-
-
-def test_get_metadata_cols():
-    """Test that get_metadata_cols extracts correct metadata including altloc."""
-    # Create a chain with altloc identifiers
-    aa_list = ['ALA', 'CYS', 'ASP']
-    arr = _make_chain(aa_list=aa_list, chain_id='A', altloc='')
-    
-    metadata_df = utils.get_metadata_cols(arr)
-    
-    # Check that all expected columns are present
-    assert 'chain' in metadata_df.columns
-    assert 'resi_struct' in metadata_df.columns
-    assert 'resn_struct' in metadata_df.columns
-    
-    # Check values
-    assert len(metadata_df) == 3
-    assert list(metadata_df['resn_struct']) == ['ALA', 'CYS', 'ASP']
-    assert list(metadata_df['resi_struct']) == [1, 2, 3]
-    assert all(metadata_df['chain'] == 'A')
 
 
 


### PR DESCRIPTION
## Goal
Improve module readability by reordering functions within existing files so helpers, constants, and public entry points appear in a more logical usage-oriented sequence. Keep the tests aligned with that source order so it is easier to find the test that corresponds to a given function.
Closes #108 

## Implementation
Reordered functions inside the targeted `src/` modules without changing module boundaries or intended behavior, with the largest updates in `runner.py`, `structure/utils.py`, and the secondary structure utilities. Reordered the matching test files so their test groups mirror the source flow, and verified the changes with Ruff plus both scoped and full pytest runs.

## Other areas
None.

Made with [Cursor](https://cursor.com)