### PR TITLE
Add UniProt AlphaFold structure loading

### DIFF
--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -37,6 +37,8 @@ class Config(BaseModel):
         Name of the protein
     pdb_id : Optional[str]
         PDB identifier for fetching structure from RCSB.
+    uniprot_id : Optional[str]
+        UniProt accession for fetching an AlphaFold-predicted structure.
     pdb_path : Optional[Path]
         Local path to structure file (PDB or mmCIF format).
     membrane_protein : Optional[bool]
@@ -78,6 +80,7 @@ class Config(BaseModel):
     # structure data
     name: Optional[str] = None
     pdb_id: Optional[str] = None
+    uniprot_id: Optional[str] = None
     pdb_path: Optional[Path] = None
     membrane_protein: Optional[bool] = False
 

--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -131,6 +131,7 @@ class Runner:
         arr = load_structure(
             path=config.pdb_path,
             pdb_id=config.pdb_id,
+            uniprot_id=config.uniprot_id,
             altloc_policy=config.altloc_policy
         )
 
@@ -176,15 +177,25 @@ class Runner:
         ss_df = get_secondary_structure_annotations(self.context)
 
         if self.context.config.membrane_protein:
-            try:
-                logger.info("Fetching PDBTM annotation")
-                pdbtm_df, tmatrix = pdbtm.fetch_pdbtm_annotation(self.context.config.pdb_id)
-                self.context.residue_table = pdbtm.add_pdbtm_regions(residue_table=self.context.residue_table, pdbtm_regions=pdbtm_df)
-                self.context.array.coord = pdbtm.transform_coordinates(self.context.array.coord, tmatrix)
-                self.context.aa = self.context.array[struc.filter_amino_acids(self.context.array)]
-                self.context.residue_table = define_membrane_secondary_structure(self.context.residue_table, ss_df)
-            except RuntimeError as e:
-                raise RuntimeError(f"Failed to fetch PDBTM annotation for {self.context.config.pdb_id}: {e}. Rerun with membrane_protein=False to calculate soluble secondary structure.")
+            if self.context.config.pdb_id is None and self.context.config.uniprot_id is not None:
+                warnings.warn(
+                    "Skipping PDBTM annotation for AlphaFold-derived structure because "
+                    "PDBTM requires a PDB ID. Membrane features will not be generated; "
+                    "continuing with soluble secondary-structure assignment.",
+                    UserWarning,
+                )
+                self.context.config.membrane_protein = False
+                self.context.residue_table = define_soluble_secondary_structure(self.context.residue_table, ss_df)
+            else:
+                try:
+                    logger.info("Fetching PDBTM annotation")
+                    pdbtm_df, tmatrix = pdbtm.fetch_pdbtm_annotation(self.context.config.pdb_id)
+                    self.context.residue_table = pdbtm.add_pdbtm_regions(residue_table=self.context.residue_table, pdbtm_regions=pdbtm_df)
+                    self.context.array.coord = pdbtm.transform_coordinates(self.context.array.coord, tmatrix)
+                    self.context.aa = self.context.array[struc.filter_amino_acids(self.context.array)]
+                    self.context.residue_table = define_membrane_secondary_structure(self.context.residue_table, ss_df)
+                except RuntimeError as e:
+                    raise RuntimeError(f"Failed to fetch PDBTM annotation for {self.context.config.pdb_id}: {e}. Rerun with membrane_protein=False to calculate soluble secondary structure.")
         else:
             self.context.residue_table = define_soluble_secondary_structure(self.context.residue_table, ss_df)
 
@@ -275,12 +286,22 @@ class Runner:
             elif base_dict.get('pdb_path') is not None:
                 # Fall back to the structure filename stem
                 base_dict['name'] = Path(base_dict['pdb_path']).stem
+            elif base_dict.get('uniprot_id') is not None:
+                # Fall back to the UniProt accession for AlphaFold-derived structures
+                base_dict['name'] = base_dict['uniprot_id']
             else:
                 raise ValueError(
                     "'name' must be provided either in config file or directly to Runner."
                 )
-        if base_dict.get('pdb_id') is None and base_dict.get('pdb_path') is None:
-            raise ValueError("Either 'pdb_id' or 'pdb_path' must be provided (in config file or directly to Runner).")
+        if (
+            base_dict.get('pdb_id') is None
+            and base_dict.get('pdb_path') is None
+            and base_dict.get('uniprot_id') is None
+        ):
+            raise ValueError(
+                "Either 'pdb_id', 'pdb_path', or 'uniprot_id' must be provided "
+                "(in config file or directly to Runner)."
+            )
 
         return Config(**base_dict)
 

--- a/src/structure/structure_context.py
+++ b/src/structure/structure_context.py
@@ -8,17 +8,20 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, gettempdir
 from typing import Literal, Optional, Union
 
 import biotite.structure as struc
 import numpy as np
 import pandas as pd
+import requests
 from biotite.database import rcsb
 from biotite.structure.io.pdb import PDBFile
 from biotite.structure.io.pdbx import CIFFile, get_structure
 
 logger = logging.getLogger(__name__)
+
+ALPHAFOLD_API_BASE = "https://alphafold.ebi.ac.uk/api/prediction"
 
 
 def residue_table(array: struc.AtomArray) -> pd.DataFrame:
@@ -47,6 +50,7 @@ def residue_table(array: struc.AtomArray) -> pd.DataFrame:
 def load_structure(
     path: Optional[Union[str, Path]] = None,
     pdb_id: Optional[str] = None,
+    uniprot_id: Optional[str] = None,
     model: Optional[int] = 1,
     altloc_policy: Literal["highest", "all"] = "highest",
 ) -> struc.AtomArray:
@@ -59,6 +63,8 @@ def load_structure(
         Path to the structure file (PDB or mmCIF format). If not provided, pdb_id must be provided.
     pdb_id : str, optional
         PDB identifier for fetching structure from RCSB. If not provided, path must be provided.
+    uniprot_id : str, optional
+        UniProt accession for fetching an AlphaFold PDB when neither path nor pdb_id is provided.
     model : int, optional
         Model number to load. Default is 1. Use None to load all models.
     altloc_policy : {'highest', 'all'}, optional
@@ -74,7 +80,7 @@ def load_structure(
     """
     extra_fields = ["b_factor", "occupancy"]
     
-    # Handle PDB ID fetching if path is not provided
+    # Handle remote fetching if path is not provided
     if path is None and pdb_id is not None:
         logger.info("Fetching PDB structure from RCSB")
         obj = rcsb.fetch(pdb_id, format="cif")
@@ -83,11 +89,15 @@ def load_structure(
         tmp_file.close()
         path = Path(tmp_file.name)
         pdb_ext = "cif"
+    elif path is None and uniprot_id is not None:
+        logger.info("Fetching AlphaFold structure from UniProt accession")
+        path = download_alphafold_pdb(uniprot_id=uniprot_id)
+        pdb_ext = path.suffix.lstrip(".")
     elif path is not None:
         path = Path(path)
         pdb_ext = path.suffix.lstrip(".")
     else:
-        raise ValueError("Either pdb_id or path must be provided")
+        raise ValueError("Either pdb_id, uniprot_id, or path must be provided")
 
     # Rename 'highest' to 'occupancy' to match biotite convention
     altloc_policy = "occupancy" if altloc_policy == 'highest' else altloc_policy
@@ -105,6 +115,39 @@ def load_structure(
             arr = pdb.get_structure(model=model or 1, extra_fields=extra_fields, altloc=altloc_policy)
     
     return arr
+
+
+def download_alphafold_pdb(uniprot_id: str, out_dir: Optional[Union[str, Path]] = None) -> Path:
+    """Download an AlphaFold PDB for a UniProt accession and return the local file path."""
+    api_url = f"{ALPHAFOLD_API_BASE}/{uniprot_id}"
+
+    try:
+        response = requests.get(api_url, timeout=30)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise RuntimeError(f"Failed to fetch AlphaFold metadata for {uniprot_id}: {e}")
+
+    data = response.json()
+    if not data:
+        raise ValueError(f"No AlphaFold prediction found for {uniprot_id}")
+
+    pdb_url = data[0].get("pdbUrl")
+    if not pdb_url:
+        raise ValueError(f"No AlphaFold PDB URL found for {uniprot_id}")
+
+    out_dir = Path(gettempdir()) if out_dir is None else Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    out_path = Path(out_dir) / f"{uniprot_id}_alphafold.pdb"
+
+    try:
+        pdb_response = requests.get(pdb_url, timeout=60)
+        pdb_response.raise_for_status()
+    except requests.RequestException as e:
+        raise RuntimeError(f"Failed to download AlphaFold PDB for {uniprot_id}: {e}")
+
+    out_path.write_bytes(pdb_response.content)
+    return out_path
 
 
 def ensure_altloc_annotation(array: struc.AtomArray) -> struc.AtomArray:

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -10,7 +10,7 @@ from tests.test_utils import _make_aaindex_data, _make_chain, _make_config_file
 
 
 def test_config(tmp_path):
-    config_args = {'pdb_id': "1abc", 'membrane_protein': True, 'mutation_data_path': "data/aaindex_parsed_small.csv",
+    config_args = {'pdb_id': "1abc", 'uniprot_id': "P12345", 'membrane_protein': True, 'mutation_data_path': "data/aaindex_parsed_small.csv",
                    'mutation_data_chain': "A", 'aaindex_path': "data/aaindex_parsed_small.csv"}
 
     _ = Config(**config_args)

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -349,11 +349,11 @@ def test_runner__merge_config(tmp_path):
     assert merged_config.mutation_data_path is None
     assert merged_config.aaindex_path == aaindex_file_path
 
-    # Test missing pdb_id and pdb_path
+    # Test missing pdb_id, pdb_path, and uniprot_id
     empty_config = Config(name='test')
-    with pytest.raises(ValueError, match="Either 'pdb_id' or 'pdb_path' must be provided"):
+    with pytest.raises(ValueError, match="Either 'pdb_id', 'pdb_path', or 'uniprot_id' must be provided"):
         myrunner._merge_config(base=empty_config, overrides={})
-    with pytest.raises(ValueError, match="Either 'pdb_id' or 'pdb_path' must be provided"):
+    with pytest.raises(ValueError, match="Either 'pdb_id', 'pdb_path', or 'uniprot_id' must be provided"):
         myrunner._merge_config(base=empty_config,
                                overrides={'membrane_protein': True})
 
@@ -364,6 +364,28 @@ def test_runner__merge_config(tmp_path):
     merged2 = myrunner._merge_config(base=empty_config,
                                      overrides={'membrane_protein': True})
     assert merged2.name == '1abc'
+
+    # Test that name is auto-derived from uniprot_id when not explicitly provided
+    uniprot_config = Config(uniprot_id='P12345')
+    merged3 = myrunner._merge_config(base=uniprot_config, overrides={})
+    assert merged3.name == 'P12345'
+
+
+def test_runner_initialization_from_uniprot_config(tmp_path):
+    """Test that Runner can initialize from config using only uniprot_id."""
+    config_path = tmp_path / 'config.toml'
+    _make_config_file(config_path, pdb_id=None, name=None, uniprot_id='P00533', mutation_data_path="")
+
+    uniprot_runner = runner.Runner(config_path=config_path)
+
+    assert uniprot_runner.context.array is not None
+    assert uniprot_runner.context.array.array_length() > 0
+    assert uniprot_runner.context.residue_table is not None
+    assert len(uniprot_runner.context.residue_table) > 0
+    assert uniprot_runner.context.config.uniprot_id == 'P00533'
+    assert uniprot_runner.context.config.pdb_id is None
+    assert uniprot_runner.context.config.pdb_path is None
+    assert uniprot_runner.context.config.name == 'P00533'
 
 
 

--- a/tests/structure/test_structure_context.py
+++ b/tests/structure/test_structure_context.py
@@ -1,8 +1,9 @@
 """Tests for structure loading utilities."""
 
 import numpy as np
+import pytest
 
-from src.structure.structure_context import load_structure, residue_table
+from src.structure.structure_context import download_alphafold_pdb, load_structure, residue_table
 from tests.test_utils import _make_chain, _write_mmcif_file
 
 
@@ -90,3 +91,19 @@ def test_load_structure_altloc_policy():
 
     arr_altloc_highest = load_structure(pdb_id='5C1M', altloc_policy='highest')
     assert len(arr_altloc_highest) < len(arr_altloc_all)
+
+
+def test_download_alphafold_pdb(tmp_path):
+    """Test downloading an AlphaFold PDB from the live AlphaFold API."""
+    out_path = download_alphafold_pdb("P00533", out_dir=tmp_path)
+
+    assert out_path == tmp_path / "P00533_alphafold.pdb"
+    assert out_path.exists()
+    assert out_path.stat().st_size > 0
+    assert b"ATOM" in out_path.read_bytes()
+
+
+def test_download_alphafold_pdb_invalid_uniprot_id(tmp_path):
+    """Test AlphaFold helper failure for an invalid UniProt accession."""
+    with pytest.raises(RuntimeError, match="Failed to fetch AlphaFold metadata for NOT_A_REAL_UNIPROT_ID"):
+        download_alphafold_pdb("NOT_A_REAL_UNIPROT_ID", out_dir=tmp_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -403,10 +403,12 @@ def _make_aaindex_data(accessions, categories=None):
 def _make_config_file(file_path: Path, pdb_id='8smv', name='test_protein', membrane_protein=False,
                       mutation_data_path=None,
                       mutation_data_chain=None, aaindex_path=None, altloc_policy='highest',
+                      uniprot_id=None,
                       structural_feature_chains=None) -> None:
     """Write a configuration file for testing in .toml format with the following defaults"""
 
     defaults = {"pdb_id": pdb_id,
+                "uniprot_id": uniprot_id,
                 'name': name,
                 "membrane_protein": membrane_protein,
                 "mutation_data_path": str(mutation_data_path) if mutation_data_path is not None else None,


### PR DESCRIPTION
## Goal
Allow pipeline configs to fetch an AlphaFold-predicted structure from a UniProt accession when no `pdb_id` or local `pdb_path` is provided.

Closes #95 

## Implementation
Add `uniprot_id` to the pipeline config and extend runner merge validation so structure loading accepts `pdb_path`, `pdb_id`, or `uniprot_id`, with names defaulting from the UniProt accession when needed. Add an AlphaFold download helper plus `load_structure()` support for UniProt accessions, and route AlphaFold-only membrane runs through the soluble path with a warning because PDBTM requires PDB IDs. Update runner and structure tests to cover the new config and live AlphaFold download path.

## Other areas
None.

## Test plan
- [x] `. .venv/bin/activate && ruff check src tests`
- [x] `. .venv/bin/activate && pytest tests/ -v`

Made with [Cursor](https://cursor.com)