### PR TITLE
Add chain-aware residue neighbor metrics

### DIFF
--- a/src/metrics/neighborhood_metrics.py
+++ b/src/metrics/neighborhood_metrics.py
@@ -62,6 +62,48 @@ def count_ala_neighbors(
     return pd.DataFrame(rows)
 
 
+def count_chain_neighbors(
+    context: Context,
+    features: pd.DataFrame,
+) -> pd.DataFrame:
+    """Count same-chain and cross-chain residues in each residue neighborhood."""
+    neighbor_map = context.extras["residue_neighbors"]
+    struct_cols = ["chain", "resi_struct", "resn_struct"]
+
+    unique = features[struct_cols].drop_duplicates()
+    unique = unique.loc[unique.resi_struct.notna(), :]
+
+    key_to_chain = dict(
+        zip(
+            (res_key(c, r, n) for c, r, n in zip(unique["chain"], unique["resi_struct"], unique["resn_struct"])),
+            unique["chain"],
+        )
+    )
+
+    rows = []
+    for _, row in unique.iterrows():
+        chain, resi, resn = row["chain"], row["resi_struct"], row["resn_struct"]
+        residue_key = res_key(chain, resi, resn)
+        neighbor_keys = neighbor_map.get(residue_key, [])
+
+        n_same_chain = sum(1 for key in neighbor_keys if key_to_chain.get(key) == chain)
+        n_different_chain = sum(
+            1 for key in neighbor_keys if key in key_to_chain and key_to_chain[key] != chain
+        )
+
+        rows.append(
+            {
+                "chain": chain,
+                "resi_struct": resi,
+                "resn_struct": resn,
+                "n_same_chain_neighbors": n_same_chain,
+                "n_different_chain_neighbors": n_different_chain,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
 def average_neighbor_metrics(
     context: Context,
     features: pd.DataFrame,
@@ -136,4 +178,4 @@ def average_neighbor_metrics(
     return pd.DataFrame(rows)
 
 
-NEIGHBORHOOD_METRIC_FUNCTIONS = [count_ala_neighbors, average_neighbor_metrics]
+NEIGHBORHOOD_METRIC_FUNCTIONS = [count_ala_neighbors, count_chain_neighbors, average_neighbor_metrics]

--- a/src/metrics/neighborhood_metrics.py
+++ b/src/metrics/neighborhood_metrics.py
@@ -66,7 +66,27 @@ def count_chain_neighbors(
     context: Context,
     features: pd.DataFrame,
 ) -> pd.DataFrame:
-    """Count same-chain and cross-chain residues in each residue neighborhood."""
+    """Number of neighboring residues on the same chain vs a different chain.
+
+    Uses context.extras['residue_neighbors'] (residue_key -> [neighbor keys]).
+    For each residue, compares each neighbor key's chain to the residue's chain
+    and counts neighbors whose chain matches vs neighbors whose chain differs.
+    Neighbor keys that do not appear in ``features`` (for example chains
+    filtered out by ``structural_feature_chains``) are ignored for both counts.
+    Uses one row per (chain, resi_struct, resn_struct) in ``features``.
+
+    Parameters
+    ----------
+    context : Context
+        Context with extras['residue_neighbors'] mapping.
+    features : pd.DataFrame
+        Merged features from Runner (must have chain, resi_struct, resn_struct).
+    Returns
+    -------
+    pd.DataFrame
+        Columns: chain, resi_struct, resn_struct, n_same_chain_neighbors,
+        n_different_chain_neighbors.
+    """
     neighbor_map = context.extras["residue_neighbors"]
     struct_cols = ["chain", "resi_struct", "resn_struct"]
 

--- a/tests/pipeline/test_neighbors.py
+++ b/tests/pipeline/test_neighbors.py
@@ -121,3 +121,35 @@ def test_calculate_neighborhood_features_neighbor_averages_deterministic():
     assert result.loc[("A", 2, "VAL"), "neighborhood_sasa"] == 1.0
     assert pd.isna(result.loc[("A", 3, "GLY"), "neighborhood_sasa"])
     assert result.loc[("A", 4, "SER"), "neighborhood_sasa"] == 6.0
+
+
+def test_calculate_neighborhood_features_chain_neighbor_counts_deterministic():
+    """Chain-aware neighbor counts separate same-chain from cross-chain neighbors."""
+    class DummyContext:
+        def __init__(self, neighbor_map):
+            self.extras = {"residue_neighbors": neighbor_map}
+
+    features = pd.DataFrame({
+        "chain": ["A", "A", "A", "B", "B", "B"],
+        "resi_struct": [1, 2, 3, 1, 2, 2],
+        "resn_struct": ["ALA", "VAL", "LEU", "GLY", "SER", "SER"],
+        "sasa": [1.0, 2.0, 5.0, 3.0, 4.0, 8.0],
+    })
+    neighbor_map = {
+        "A:1:ALA": ["A:2:VAL", "B:1:GLY", "B:999:UNK"],
+        "A:2:VAL": ["A:1:ALA", "A:3:LEU"],
+        "A:3:LEU": ["A:2:VAL"],
+        "B:1:GLY": ["B:2:SER"],
+        "B:2:SER": ["A:2:VAL", "B:1:GLY"],
+    }
+    context = DummyContext(neighbor_map)
+
+    result = calculate_neighborhood_features(context, features)
+    result = result.set_index(["chain", "resi_struct", "resn_struct"])
+
+    assert result.loc[("A", 1, "ALA"), "n_same_chain_neighbors"] == 1
+    assert result.loc[("A", 1, "ALA"), "n_different_chain_neighbors"] == 1
+    assert result.loc[("A", 2, "VAL"), "n_same_chain_neighbors"] == 2
+    assert result.loc[("A", 2, "VAL"), "n_different_chain_neighbors"] == 0
+    assert result.loc[("B", 1, "GLY"), "n_same_chain_neighbors"] == 1
+    assert result.loc[("B", 1, "GLY"), "n_different_chain_neighbors"] == 0


### PR DESCRIPTION
Goal
Add residue neighborhood metrics that split neighboring residues into same-chain and different-chain counts so interface contacts are visible directly in the feature table.

Implementation
Add a new neighborhood metric in `src/metrics/neighborhood_metrics.py` that reads `context.extras[\"residue_neighbors\"]` and outputs `n_same_chain_neighbors` plus `n_different_chain_neighbors`. Register the metric in `NEIGHBORHOOD_METRIC_FUNCTIONS` so it is merged into neighborhood features automatically. Add a deterministic test in `tests/pipeline/test_neighbors.py` covering cross-chain counting, zero cross-chain neighbors, two same-chain neighbors, and ignored unresolved neighbor keys.

Other areas
None.

## Test plan
- [x] `ruff check src tests`
- [x] `pytest tests/pipeline/test_neighbors.py -v -x`
- [x] `pytest tests/ -v`

Made with [Cursor](https://cursor.com)