### PR TITLE
Add sequence-window averages for sequence metrics

### DIFF
--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -24,8 +24,8 @@ from src.pipeline.context import Config, Context
 from src.pipeline.ligands import calculate_protein_ligand_interactions
 from src.pipeline.neighbors import calculate_neighborhood_features, compute_residue_neighbors
 from src.pipeline.secondary_structure_features import calculate_secondary_structure_features
-from src.pipeline.sequence_window_features import calculate_sequence_window_features
 from src.pipeline.sequence_alignment import load_mutation_scores, merge_mutation_scores
+from src.pipeline.sequence_window_features import calculate_sequence_window_features
 from src.structure.secondary_structure import (
     define_membrane_secondary_structure,
     define_soluble_secondary_structure,

--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -24,6 +24,7 @@ from src.pipeline.context import Config, Context
 from src.pipeline.ligands import calculate_protein_ligand_interactions
 from src.pipeline.neighbors import calculate_neighborhood_features, compute_residue_neighbors
 from src.pipeline.secondary_structure_features import calculate_secondary_structure_features
+from src.pipeline.sequence_window_features import calculate_sequence_window_features
 from src.pipeline.sequence_alignment import load_mutation_scores, merge_mutation_scores
 from src.structure.secondary_structure import (
     define_membrane_secondary_structure,
@@ -381,12 +382,19 @@ class Runner:
         """
         
         result_frames = []
+        sequence_metric_columns: list[str] = []
         
         for m in metrics:
             meta, func = _REGISTRY[m]
 
             logger.info(f"Calculating metric: {m}")
             df = func(self.context)
+            if "sequence" in meta.tags:
+                sequence_metric_columns.extend(
+                    column
+                    for column in df.columns
+                    if column not in {"chain", "resi_struct", "resn_struct", "resi_mut", "resn_mut", "resm"}
+                )
 
             result_frames.append(df)
         
@@ -394,6 +402,7 @@ class Runner:
         logger.info("Merging features")
         features = self._merge_features(result_frames, mutations=mutations)
         features['name'] = self.context.config.name
+        self._sequence_metric_columns = list(dict.fromkeys(sequence_metric_columns))
         return features
     
     
@@ -424,6 +433,20 @@ class Runner:
 
         # Run metrics
         self.features = self.run_metrics(metrics=metrics, mutations=mutations)
+        sequence_window_features = calculate_sequence_window_features(
+            self.context,
+            self.features,
+            seq_metric_columns=getattr(self, "_sequence_metric_columns", []),
+            window_size=5,
+        )
+        if not sequence_window_features.empty:
+            self.features = pd.merge(
+                self.features,
+                sequence_window_features,
+                on=["chain", "resi_mut", "resn_mut"],
+                how="left",
+                validate="many_to_one",
+            )
 
         merge_cols = ['chain', 'resi_struct', 'resn_struct']
 

--- a/src/pipeline/sequence_window_features.py
+++ b/src/pipeline/sequence_window_features.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+from pandas.api.types import is_bool_dtype, is_numeric_dtype
+
+from src.pipeline.context import Context
+
+SEQUENCE_MERGE_COLS = ["chain", "resi_mut", "resn_mut"]
+
+
+def calculate_sequence_window_features(
+    context: Context,
+    features: pd.DataFrame,
+    seq_metric_columns: Iterable[str],
+    window_size: int = 5,
+) -> pd.DataFrame:
+    """Average numeric sequence-derived features across a centered sequence window.
+
+    Parameters
+    ----------
+    context : Context
+        Pipeline context containing ``residue_table`` with sequence-position ordering
+        in ``align_pos``.
+    features : pd.DataFrame
+        Merged runner feature table. When mutation data is present, this may contain
+        multiple rows per residue, one for each mutation.
+    seq_metric_columns : Iterable[str]
+        Concrete feature columns produced by sequence-tagged metrics during
+        ``Runner.run_metrics()``.
+    window_size : int
+        Size of the centered residue window used for the rolling mean.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per residue with ``chain``, ``resi_mut``, ``resn_mut``, and
+        ``sequence_window_*`` columns for numeric sequence-derived metrics.
+
+    Notes
+    -----
+    Mutation-level rows are first collapsed to one residue-level value by averaging
+    each numeric sequence metric. The rolling mean is then computed in ``align_pos``
+    order within each chain, using only residues that already have at least one
+    numeric sequence metric value.
+    """
+    seq_metric_columns = list(dict.fromkeys(seq_metric_columns))
+    # Limit the rolling step to realized numeric sequence metrics and skip labels.
+    numeric_cols = [
+        column
+        for column in seq_metric_columns
+        if column in features.columns
+        and is_numeric_dtype(features[column])
+        and not is_bool_dtype(features[column])
+    ]
+    if not numeric_cols:
+        return pd.DataFrame(columns=SEQUENCE_MERGE_COLS)
+
+    # Align sequence metrics to a unique residue ordering before collapsing mutation rows.
+    align_pos = (
+        context.residue_table[SEQUENCE_MERGE_COLS + ["align_pos"]]
+        .drop_duplicates(SEQUENCE_MERGE_COLS)
+        .reset_index(drop=True)
+    )
+    residue_level = pd.merge(
+        features[SEQUENCE_MERGE_COLS + numeric_cols],
+        align_pos,
+        on=SEQUENCE_MERGE_COLS,
+        how="left",
+        validate="many_to_one",
+    )
+    # Residue-level inputs for the window come from the mean across mutation rows.
+    residue_level = residue_level.groupby(
+        SEQUENCE_MERGE_COLS + ["align_pos"],
+        as_index=False,
+    ).agg({column: "mean" for column in numeric_cols})
+
+    # Exclude residues with no numeric sequence metrics from the rolling series.
+    residue_level = residue_level.loc[residue_level[numeric_cols].notna().any(axis=1), :]
+    if residue_level.empty:
+        return pd.DataFrame(columns=SEQUENCE_MERGE_COLS)
+
+    # Apply the centered rolling mean independently within each chain.
+    residue_level = residue_level.sort_values(["chain", "align_pos"], kind="mergesort").reset_index(drop=True)
+    for column in numeric_cols:
+        residue_level[f"sequence_window_{column}"] = (
+            residue_level.groupby("chain")[column]
+            .transform(
+                lambda values: values.rolling(
+                    window=window_size,
+                    center=True,
+                    min_periods=1,
+                ).mean()
+            )
+        )
+
+    window_cols = [f"sequence_window_{column}" for column in numeric_cols]
+    return residue_level[SEQUENCE_MERGE_COLS + window_cols]

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -696,6 +696,67 @@ def test_runner_run(tmp_path):
     assert returned_features[all_graph_cols].notna().any().any(), "graph_all_* columns are all null."
 
 
+def test_runner_run_adds_sequence_window_features(tmp_path):
+    residue_table = _make_residue_table(
+        num_chains=1,
+        num_residues=6,
+        start_resis=1,
+        make_muts=True,
+    )
+    mut_dataset = residue_table[["resn_mut", "resi_mut", "resm", "effect", "type"]].rename(
+        columns={
+            "resn_mut": "wildtype",
+            "resi_mut": "position",
+            "resm": "mutation",
+        }
+    )
+    mut_data_path = tmp_path / "mut_data.csv"
+    mut_dataset.to_csv(mut_data_path, index=False)
+
+    residues = residue_table[["resn_mut", "resi_mut"]].drop_duplicates()["resn_mut"]
+    mmcif_path = tmp_path / "test_structure.cif"
+    _write_mmcif_file(file_path=mmcif_path, pdb_id="TEST", chains={"A": residues.tolist()})
+
+    config_path = tmp_path / "config.toml"
+    _make_config_file(config_path, mutation_data_path=mut_data_path, mutation_data_chain="A")
+
+    myrunner = runner.Runner(
+        pdb_id="TEST",
+        name="test_sequence_window_run",
+        pdb_path=mmcif_path,
+        membrane_protein=False,
+        mutation_data_path=mut_data_path,
+        config_path=config_path,
+    )
+    myrunner.context.extras["bonds_df"] = pd.DataFrame(
+        columns=[
+            "chain",
+            "resi_struct",
+            "resn_struct",
+            "partner_chain",
+            "partner_resi",
+            "partner_resn",
+            "partner_residue_key",
+            "bond_type",
+            "protein_protein",
+            "extras",
+        ]
+    )
+
+    myrunner.run(metrics=["effect_ranking", "blosum_score", "aa_groupings"])
+
+    assert "sequence_window_effect" in myrunner.features.columns
+    assert "sequence_window_effect_ranking" in myrunner.features.columns
+    assert "sequence_window_blosum90" in myrunner.features.columns
+    assert "sequence_window_mut_aa_group" not in myrunner.features.columns
+    assert myrunner.features["sequence_window_effect"].notna().any()
+
+    residue_level = myrunner.features[
+        ["chain", "resi_mut", "resn_mut", "sequence_window_effect"]
+    ].drop_duplicates()
+    assert len(residue_level) == residue_table["resi_mut"].nunique()
+
+
 def test_run_neighborhood_requires_run_first(tmp_path):
     """run_neighborhood must be called after run(); it raises if self.features is missing."""
     config_path = tmp_path / 'config.toml'

--- a/tests/pipeline/test_sequence_window_features.py
+++ b/tests/pipeline/test_sequence_window_features.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pandas as pd
+
+from src.pipeline.sequence_window_features import calculate_sequence_window_features
+
+
+class DummyContext:
+    def __init__(self, residue_table: pd.DataFrame):
+        self.residue_table = residue_table
+
+
+def test_calculate_sequence_window_features_collapses_and_rolls():
+    residue_table = pd.DataFrame(
+        {
+            "chain": ["A"] * 6,
+            "resi_mut": [1, 2, 3, 4, 5, 6],
+            "resn_mut": ["ALA", "ARG", "CYS", "ASP", "GLU", "PHE"],
+            "align_pos": [10, 20, 30, 40, 50, 60],
+        }
+    )
+    features = pd.DataFrame(
+        {
+            "chain": ["A"] * 12,
+            "resi_mut": [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6],
+            "resn_mut": ["ALA", "ALA", "ARG", "ARG", "CYS", "CYS", "ASP", "ASP", "GLU", "GLU", "PHE", "PHE"],
+            "effect": [2.0, 4.0, 4.0, 6.0, 6.0, 8.0, np.nan, np.nan, 10.0, 12.0, 12.0, 14.0],
+            "blosum90": [1.0, 3.0, 2.0, 4.0, 3.0, 5.0, np.nan, np.nan, 5.0, 7.0, 6.0, 8.0],
+            "AA1_hydrophobicity_mut": [10.0, 14.0, 20.0, 24.0, 30.0, 34.0, np.nan, np.nan, 50.0, 54.0, 60.0, 64.0],
+            "effect_quartile": ["Q1", "Q1", "Q2", "Q2", "Q3", "Q3", None, None, "Q4", "Q4", "Q4", "Q4"],
+            "mut_aa_group": ["A", "B", "A", "B", "A", "B", None, None, "A", "B", "A", "B"],
+        }
+    )
+
+    result = calculate_sequence_window_features(
+        DummyContext(residue_table),
+        features,
+        seq_metric_columns=[
+            "effect",
+            "blosum90",
+            "AA1_hydrophobicity_mut",
+            "effect_quartile",
+            "mut_aa_group",
+        ],
+        window_size=5,
+    ).set_index(["chain", "resi_mut", "resn_mut"])
+
+    assert len(result) == 5
+    assert ("A", 4, "ASP") not in result.index
+    assert "sequence_window_effect_quartile" not in result.columns
+    assert "sequence_window_mut_aa_group" not in result.columns
+    assert "sequence_window_AA1_hydrophobicity_mut" in result.columns
+
+    assert np.isclose(result.loc[("A", 1, "ALA"), "sequence_window_effect"], 5.0)
+    assert np.isclose(result.loc[("A", 3, "CYS"), "sequence_window_effect"], 7.8)
+    assert np.isclose(result.loc[("A", 5, "GLU"), "sequence_window_effect"], 9.0)
+    assert np.isclose(result.loc[("A", 3, "CYS"), "sequence_window_blosum90"], 4.4)
+    assert np.isclose(
+        result.loc[("A", 3, "CYS"), "sequence_window_AA1_hydrophobicity_mut"],
+        36.0,
+    )
+
+
+def test_calculate_sequence_window_features_returns_empty_without_numeric_metrics():
+    residue_table = pd.DataFrame(
+        {
+            "chain": ["A"],
+            "resi_mut": [1],
+            "resn_mut": ["ALA"],
+            "align_pos": [1],
+        }
+    )
+    features = pd.DataFrame(
+        {
+            "chain": ["A"],
+            "resi_mut": [1],
+            "resn_mut": ["ALA"],
+            "effect_quartile": ["Q1"],
+        }
+    )
+
+    result = calculate_sequence_window_features(
+        DummyContext(residue_table),
+        features,
+        seq_metric_columns=["effect_quartile"],
+        window_size=5,
+    )
+
+    assert result.empty
+    assert list(result.columns) == ["chain", "resi_mut", "resn_mut"]


### PR DESCRIPTION
## Goal
Add centered sliding-window averages for sequence-derived metrics so runner outputs include residue-level local context from the sequence feature set.

## Implementation
Track the concrete columns produced by metrics tagged `sequence` during `Runner.run_metrics()`, then compute `sequence_window_*` features in a new `src/pipeline/sequence_window_features.py` helper. The helper filters to numeric sequence-derived columns, collapses mutation rows to residue level by mean, orders residues by `align_pos`, computes a centered windowed mean within each chain, and merges those values back onto `self.features` before downstream secondary-structure, neighborhood, ligand, and graph integrations. Added focused helper tests plus a runner integration test.

## Other areas
None.

## Test plan
- [x] `pytest tests/pipeline/test_sequence_window_features.py tests/pipeline/test_runner.py -k "sequence_window" -v -x`
- [x] `pytest tests/pipeline/test_runner.py tests/pipeline/test_secondary_structure_features.py tests/pipeline/test_neighbors.py -v -x`
- [ ] `pytest tests/ -v` currently stops on an unrelated local environment issue: `tests/structure/test_secondary_structure.py::test_get_secondary_structure_annotations` fails because `pydssp` is not installed.