### PR TITLE
Refactor amino acid conversion and mutation validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,17 @@ A CSV file with one row per mutation. Default required columns (names configurab
 | Residue position | `position` | Integer residue number |
 | Wildtype amino acid | `wildtype` | 1-letter or 3-letter code |
 | Mutant amino acid | `mutation` | 1-letter or 3-letter code |
-| Mutation type | `type` | `"missense"`, `"synonymous"`, `"stop_codon"` |
+| Mutation type | `type` | `"missense"`, `"synonymous"`, `"stop"`, `"deletion"`, or `"insertion"` |
 | Effect score | `effect` | Numerical fitness / effect score |
+
+#### Mutation input requirements
+
+- `wildtype` must use a single code system across the file: either all 1-letter amino acid codes or all 3-letter amino acid codes.
+- `mutation` may use standard 1-letter amino acid codes, standard 3-letter amino acid codes, `*`, or the shorthand indel tokens `DEL`, `DEL1`, `DEL2`, `DEL3`, `INS1`, `INS2`, and `INS3`.
+- Mixed `mutation` formats are allowed. Standard 1-letter mutant amino acid codes are normalized to 3-letter codes during loading; the explicit indel shorthand tokens remain unchanged.
+- `type` must use one of the canonical values `missense`, `synonymous`, `stop`, `deletion`, or `insertion`.
+
+Loader validation errors reference this section as `README.md#mutation-input-requirements`.
 
 The pipeline aligns the mutation data sequence to the PDB chain you specify via
 `mutation_data_chain`.  Alignment warnings (mismatches, gaps) are reported in the
@@ -288,7 +297,7 @@ It records:
 | `resn_struct` | Residue name (3-letter) from the structure |
 | `resi_mut` | Residue number from mutation data (same as `resi_struct` in structure-only mode) |
 | `resn_mut` | Residue name from mutation data |
-| `resm` | Mutant residue 1-letter code (DMS mode only) |
+| `resm` | Mutant residue token after loading, typically 3-letter for substitutions and unchanged for explicit indel shorthand tokens |
 | `name` | Run name (derived from PDB ID or the `name` parameter) |
 | `ss_domains` | Secondary structure domain label (e.g. `helix_1`, `sheet_2`, `coil_3`) |
 

--- a/src/metrics/sequence.py
+++ b/src/metrics/sequence.py
@@ -9,7 +9,7 @@ from Bio.Align import substitution_matrices
 from src.metrics.aaindex_schema import AAINDEX_AA_COLUMNS
 from src.metrics.registry import register_metric
 from src.pipeline.context import Context
-from src.sequence.utils import convert_amino_acid
+from src.sequence.utils import convert_amino_acid_3to1
 
 logger = logging.getLogger(__name__)
 
@@ -300,8 +300,8 @@ def calculate_blosum_score(context: Context) -> pd.DataFrame:
     b_matrix = bl.BLOSUM(blosum_threshold)
 
     def get_blosum_score(row):
-        wt = convert_amino_acid(row['resn_mut'])
-        mut = convert_amino_acid(row['resm'])
+        wt = convert_amino_acid_3to1(row['resn_mut'])
+        mut = convert_amino_acid_3to1(row['resm'])
         return b_matrix[wt][mut]
 
     blosum_scores[f'blosum{blosum_threshold}'] = blosum_scores.apply(get_blosum_score, axis=1)
@@ -330,8 +330,8 @@ def calculate_phat_score(context: Context) -> pd.DataFrame:
     PHAT75_73 = make_phat75_73()
 
     def get_phat_score(row):
-        wt = convert_amino_acid(row['resn_mut'])
-        mut = convert_amino_acid(row['resm'])
+        wt = convert_amino_acid_3to1(row['resn_mut'])
+        mut = convert_amino_acid_3to1(row['resm'])
         if wt not in PHAT75_73.alphabet or mut not in PHAT75_73.alphabet:
             return np.inf
         return PHAT75_73[wt][mut]

--- a/src/pipeline/sequence_alignment.py
+++ b/src/pipeline/sequence_alignment.py
@@ -13,13 +13,22 @@ from typing import Tuple, Union
 import pandas as pd
 from Bio.Align import PairwiseAligner
 
-from src.sequence.utils import convert_amino_acid
+from src.sequence.utils import (
+    VALID_1_CODES,
+    VALID_RESM_3_CODES,
+    VALID_RESN_3_CODES,
+    convert_amino_acid_1to3,
+    convert_amino_acid_3to1,
+    invalid_codes,
+)
 
 logger = logging.getLogger(__name__)
 
 # User-facing labels for alignment warnings (merged columns use resn_df1 / resn_df2 before rename).
 _LABEL_MUTATION = "mutation sequence"
 _LABEL_STRUCTURAL = "structural sequence"
+_MUTATION_INPUT_README_SECTION = "README.md#mutation-input-requirements"
+VALID_MUTATION_TYPES = frozenset({"missense", "synonymous", "stop", "deletion", "insertion"})
 
 
 def _format_residue_ranges(positions: pd.Series) -> str:
@@ -87,10 +96,6 @@ def load_mutation_scores(
         If required columns are missing or if the residue column contains
         codes that are neither 1-letter nor 3-letter amino acid codes.
 
-    Warns
-    -----
-    UserWarning
-        If mutation types contain unexpected values.
     """
     logger.info("Loading mutation scores")
     df = pd.read_csv(path)
@@ -116,28 +121,63 @@ def load_mutation_scores(
         score_col_name: "effect"
     })
 
-    # make sure that residue and mutation columns are valid
-    residue_lens = df['resn'].str.len().unique()
-    if len(residue_lens) != 1 or residue_lens[0] not in (1, 3):
-        raise ValueError("Residue column must contain either 1-letter or 3-letter amino acid codes.")
+    df["resn"] = df["resn"].astype(str).str.strip().str.upper()
+    df["resm"] = df["resm"].astype(str).str.strip().str.upper()
+    df["type"] = df["type"].astype(str).str.strip().str.lower()
 
-    # mutation column may contain a range of possible lengths because of stops and indels
-    mutation_lens = df['resm'].str.len().unique()
+    # Wildtype residues must use a single code system because they define the sequence.
+    residue_lens = set(df["resn"].str.len().unique())
+    if residue_lens == {1}:
+        invalid_resn = invalid_codes(set(df["resn"].unique()), VALID_1_CODES)
+        if invalid_resn:
+            raise ValueError(
+                f"Wildtype residue column contains invalid 1-letter codes: {sorted(invalid_resn)}. "
+                f"See {_MUTATION_INPUT_README_SECTION}."
+            )
+        df["resn"] = df["resn"].map(convert_amino_acid_1to3)
+    elif residue_lens == {3}:
+        invalid_resn = invalid_codes(set(df["resn"].unique()), VALID_RESN_3_CODES)
+        if invalid_resn:
+            raise ValueError(
+                f"Wildtype residue column contains invalid 3-letter codes: {sorted(invalid_resn)}. "
+                f"See {_MUTATION_INPUT_README_SECTION}."
+            )
+    else:
+        raise ValueError(
+            "Wildtype residue column must contain only valid 1-letter or only valid 3-letter amino acid codes. "
+            f"See {_MUTATION_INPUT_README_SECTION}."
+        )
 
-    # convert to 3-letter codes if necessary
-    if residue_lens[0] == 1:
-        df['resn'] = df['resn'].apply(convert_amino_acid)
+    mutant_lens = set(df["resm"].str.len().unique())
+    if not mutant_lens.issubset({1, 3, 4}):
+        invalid_resm = sorted(code for code in df["resm"].unique() if len(code) not in {1, 3, 4})
+        raise ValueError(
+            f"Mutant residue column contains unsupported tokens: {invalid_resm}. "
+            f"See {_MUTATION_INPUT_README_SECTION}."
+        )
 
-    if 1 in mutation_lens:
-        df['resm'] = df['resm'].apply(convert_amino_acid)
+    invalid_resm_1 = invalid_codes({code for code in df["resm"].unique() if len(code) == 1}, VALID_1_CODES)
+    invalid_resm_3 = invalid_codes({code for code in df["resm"].unique() if len(code) == 3}, VALID_RESM_3_CODES)
+    invalid_resm_4 = invalid_codes({code for code in df["resm"].unique() if len(code) == 4}, VALID_RESM_3_CODES)
+    invalid_resm = sorted(invalid_resm_1 | invalid_resm_3 | invalid_resm_4)
+    if invalid_resm:
+        raise ValueError(
+            f"Mutant residue column contains invalid codes: {invalid_resm}. "
+            f"See {_MUTATION_INPUT_README_SECTION}."
+        )
 
-    # check that mutation types are named in a standard way
-    valid_types = {'missense', 'nonsense', 'silent', 'insertion', 'deletion', 'synonymous', 'indel', 'del', 'ins', 'stop'}
-    found_types = set(df['type'].unique())
-    if not found_types.issubset(valid_types):
-        invalid_types = found_types - valid_types
-        warnings.warn(f"Mutation types contain unexpected values. Expected types include {valid_types}. "
-                      f"Found invalid types: {invalid_types}.")
+    df["resm"] = df["resm"].map(
+        lambda code: convert_amino_acid_1to3(code) if len(code) == 1 else code
+    )
+
+    found_types = set(df["type"].unique())
+    invalid_types = found_types - VALID_MUTATION_TYPES
+    if invalid_types:
+        raise ValueError(
+            f"Mutation type column contains invalid values: {sorted(invalid_types)}. "
+            f"Expected one of {sorted(VALID_MUTATION_TYPES)}. "
+            f"See {_MUTATION_INPUT_README_SECTION}."
+        )
 
     return df
 
@@ -365,9 +405,9 @@ def merge_mutation_scores(
     )
 
     # Prepare sequences for alignment, a single string of single-letter amino acids
-    mut_seq_short = mutation_scores_subset['resn'].apply(lambda aa: convert_amino_acid(aa, force_convert=True))
+    mut_seq_short = mutation_scores_subset['resn'].apply(lambda aa: convert_amino_acid_3to1(aa, force_convert=True))
     mut_seq = "".join(mut_seq_short.tolist())
-    res_seq_short = residue_table_chain['resn'].apply(lambda aa: convert_amino_acid(aa, force_convert=True))
+    res_seq_short = residue_table_chain['resn'].apply(lambda aa: convert_amino_acid_3to1(aa, force_convert=True))
     res_seq = "".join(res_seq_short.tolist())
 
     # Perform alignment

--- a/src/sequence/utils.py
+++ b/src/sequence/utils.py
@@ -1,78 +1,90 @@
 """
 Sequence utility functions for amino acid code conversion.
 
-This module provides utilities for working with amino acid sequences,
-including conversion between 1-letter and 3-letter amino acid codes.
+This module provides directional helpers for working with amino acid codes and
+mutation tokens used by the mutation-score loader.
 """
 
 import warnings
 
-# Bi-directional mapping between amino acid codes
-AA_3_TO_1 = {
+STANDARD_AA_3_TO_1 = {
     "ALA": "A", "ARG": "R", "ASN": "N", "ASP": "D",
     "CYS": "C", "GLN": "Q", "GLU": "E", "GLY": "G",
     "HIS": "H", "ILE": "I", "LEU": "L", "LYS": "K",
     "MET": "M", "PHE": "F", "PRO": "P", "SER": "S",
-    "THR": "T", "TRP": "W", "TYR": "Y", "VAL": "V", 
-    "DEL": "DEL", "*": "*", "del": "del"
+    "THR": "T", "TRP": "W", "TYR": "Y", "VAL": "V",
+    "*": "*",
 }
 
-# Automatically create the reverse mapping
-AA_1_TO_3 = {v: k for k, v in AA_3_TO_1.items()}
+# Mutation shorthands are valid mutant tokens but collapse to X when a single
+# residue character is needed for alignment or substitution matrices.
+SPECIAL_TOKEN_3_TO_1 = {
+    "DEL": "X",
+    "DEL1": "X",
+    "DEL2": "X",
+    "DEL3": "X",
+    "INS1": "X",
+    "INS2": "X",
+    "INS3": "X",
+}
+
+AA_3_TO_1 = {
+    **STANDARD_AA_3_TO_1,
+    **SPECIAL_TOKEN_3_TO_1,
+}
+AA_1_TO_3 = {v: k for k, v in STANDARD_AA_3_TO_1.items()}
+
+VALID_RESN_3_CODES = frozenset(STANDARD_AA_3_TO_1)
+VALID_RESM_3_CODES = frozenset(AA_3_TO_1)
+VALID_1_CODES = frozenset(AA_1_TO_3)
 
 
-def convert_amino_acid(code: str, force_convert: bool = False) -> str:
+def convert_amino_acid_1to3(code: str, force_convert: bool = False) -> str:
     """
-    Convert between 1-letter and 3-letter amino acid codes.
+    Convert a 1-letter amino acid code to a 3-letter code.
 
-    Parameters
-    ----------
-    code : str
-        Either a 1-letter or 3-letter amino acid code.
-    force_convert : bool, optional
-        If True, forces conversion even if the code is unrecognized: 1-letter codes
-        will be repeated 3 times, and 3-letter codes will be converted to 'X'.
-
-    Returns
-    -------
-    str
-        The corresponding 3-letter or 1-letter code. If the input is a
-        1-letter code, returns the 3-letter code, and vice versa.
-
-    Warns
-    -----
-    UserWarning
-        If the provided code is not recognized or has an unexpected length.
-
-    Raises
-    ------
-    ValueError
-        If force_convert is True and the code is not of length 1 or 3.
+    Unknown 1-letter tokens warn and round-trip unchanged unless
+    ``force_convert`` is set, in which case the single character is repeated.
     """
     code = code.upper().strip()
-    if len(code) == 1:
-        if code in AA_1_TO_3:
-            return AA_1_TO_3[code]
-        else:
-            warnings.warn(f"Unknown 1 letter code: {code}")
-            if force_convert:
-                return code * 3
-            else:
-                return code
+    if len(code) != 1:
+        if force_convert:
+            raise ValueError(f"Cannot convert 1-letter amino acid code: {code}")
+        warnings.warn(f"Unexpected 1 letter amino acid code length: {code}")
+        return code
 
-    elif len(code) == 3:
-        if code in AA_3_TO_1:
-            return AA_3_TO_1[code]
-        else:
-            warnings.warn(f"Unknown 3 letter code: {code}")
-            if force_convert:
-                return 'X'
-            else:
-                return code
+    if code in AA_1_TO_3:
+        return AA_1_TO_3[code]
 
+    warnings.warn(f"Unknown 1 letter code: {code}")
     if force_convert:
-        raise ValueError(f"Cannot convert amino acid code: {code}")
+        return code * 3
+    return code
+
+
+def convert_amino_acid_3to1(code: str, force_convert: bool = False) -> str:
+    """
+    Convert a 3-letter residue code or mutation token to a 1-letter code.
+
+    Known deletion/insertion shorthand tokens are treated as valid inputs and
+    collapse to ``X`` so downstream alignment and sequence-matrix code can keep
+    a single-character representation.
+    """
+    code = code.upper().strip()
+    if code in AA_3_TO_1:
+        return AA_3_TO_1[code]
+
+    if len(code) == 3:
+        warnings.warn(f"Unknown 3 letter code: {code}")
     else:
         warnings.warn(f"Unexpected amino acid code length: {code}")
-        return code
+
+    if force_convert:
+        return "X"
+    return code
+
+
+def invalid_codes(codes: set[str], valid_codes: frozenset[str]) -> set[str]:
+    """Return normalized codes that are not present in the allowed set."""
+    return {code for code in codes if code not in valid_codes}
 

--- a/tests/metrics/test_sequence.py
+++ b/tests/metrics/test_sequence.py
@@ -7,7 +7,7 @@ import pytest
 
 from src.metrics import sequence as metrics
 from src.metrics.aaindex_schema import AAINDEX_AA_COLUMNS
-from src.sequence.utils import convert_amino_acid
+from src.sequence.utils import convert_amino_acid_3to1
 from tests.test_utils import AA_LIST, _make_aaindex_data, _make_residue_table
 
 # Seed RNGs for deterministic tests
@@ -354,7 +354,7 @@ def test_calculate_blosum_score():
     # verify that values are correct
     b_matrix = metrics.bl.BLOSUM(90)
     for idx, row in blosum_df.iterrows():
-        expected_score = b_matrix[convert_amino_acid(row['resn_mut'])][convert_amino_acid(row['resm'])]
+        expected_score = b_matrix[convert_amino_acid_3to1(row['resn_mut'])][convert_amino_acid_3to1(row['resm'])]
         assert blosum_df.at[idx, 'blosum90'] == expected_score
 
 

--- a/tests/pipeline/test_sequence_alignment.py
+++ b/tests/pipeline/test_sequence_alignment.py
@@ -20,7 +20,7 @@ def test_load_mutation_scores(tmp_path):
         'resn_rename': ['ARG', 'THR', 'GLU'],
         'resi_rename': [1, 2, 3],
         'resm_rename': ['ALA', 'CYS', 'ASP'],
-        'type_rename': ['missense', 'missense', 'nonsense'],
+        'type_rename': ['missense', 'missense', 'stop'],
         'effect_rename': [0.5, -1.2, 0.3]
     })
 
@@ -44,7 +44,7 @@ def test_load_mutation_scores(tmp_path):
     test_file_invalid_path_res = os.path.join(tmp_path, 'test_mutation_scores_invalid_res.csv')
     test_df.to_csv(test_file_invalid_path_res, index=False)
 
-    with pytest.raises(ValueError, match="Residue column must contain either 1-letter or 3-letter amino acid codes."):
+    with pytest.raises(ValueError, match="Wildtype residue column must contain only valid 1-letter or only valid 3-letter amino acid codes"):
         load_mutation_scores(
             path=test_file_invalid_path_res,
             residue_col_name='resn_rename',
@@ -56,13 +56,13 @@ def test_load_mutation_scores(tmp_path):
 
 
 def test_load_mutation_scores_1letter_mutation_conversion(tmp_path):
-    """Test conversion of 1-letter mutation codes to 3-letter codes (lines 87-88)."""
+    """Test conversion of 1-letter mutation codes to 3-letter codes."""
     # Create mutation scores with 3-letter wildtype and 1-letter mutant codes
     test_df = pd.DataFrame({
         'resn_col': ['ARG', 'THR', 'GLU'],  # 3-letter wildtype codes
         'resi_col': [1, 2, 3],
         'resm_col': ['A', 'C', 'D'],  # All 1-letter mutant codes
-        'type_col': ['missense', 'missense', 'nonsense'],
+        'type_col': ['missense', 'missense', 'stop'],
         'effect_col': [0.5, -1.2, 0.3]
     })
     
@@ -83,8 +83,128 @@ def test_load_mutation_scores_1letter_mutation_conversion(tmp_path):
     assert all(len(resn) == 3 for resn in loaded_df['resn'])
     
     # Verify that 1-letter mutant codes are converted to 3-letter codes
-    # This tests lines 87-88 where convert_amino_acid is applied to mutation column
     assert loaded_df['resm'].tolist() == ['ALA', 'CYS', 'ASP']
+
+
+def test_load_mutation_scores_mixed_mutation_tokens(tmp_path):
+    """1-letter mutants should normalize without flipping 3-letter/special tokens."""
+    test_df = pd.DataFrame({
+        'resn_col': ['ARG', 'THR', 'GLU', 'SER'],
+        'resi_col': [1, 2, 3, 4],
+        'resm_col': ['A', 'CYS', 'DEL1', '*'],
+        'type_col': ['missense', 'missense', 'deletion', 'stop'],
+        'effect_col': [0.5, -1.2, 0.3, -0.7],
+    })
+
+    test_file_path = os.path.join(tmp_path, 'test_mutation_mixed_tokens.csv')
+    test_df.to_csv(test_file_path, index=False)
+
+    loaded_df = load_mutation_scores(
+        path=test_file_path,
+        residue_col_name='resn_col',
+        residue_idx_name='resi_col',
+        mutation_col_name='resm_col',
+        mutation_type_col_name='type_col',
+        score_col_name='effect_col'
+    )
+
+    assert loaded_df['resm'].tolist() == ['ALA', 'CYS', 'DEL1', '*']
+
+
+def test_load_mutation_scores_invalid_resn_code(tmp_path):
+    """Invalid wildtype residue codes should raise a README-linked error."""
+    test_df = pd.DataFrame({
+        'resn_col': ['ARG', 'BAD'],
+        'resi_col': [1, 2],
+        'resm_col': ['ALA', 'CYS'],
+        'type_col': ['missense', 'missense'],
+        'effect_col': [0.5, -1.2],
+    })
+
+    test_file_path = os.path.join(tmp_path, 'test_invalid_resn.csv')
+    test_df.to_csv(test_file_path, index=False)
+
+    with pytest.raises(ValueError, match=r"Wildtype residue column contains invalid 3-letter codes: \['BAD'\].*README.md#mutation-input-requirements"):
+        load_mutation_scores(
+            path=test_file_path,
+            residue_col_name='resn_col',
+            residue_idx_name='resi_col',
+            mutation_col_name='resm_col',
+            mutation_type_col_name='type_col',
+            score_col_name='effect_col'
+        )
+
+
+def test_load_mutation_scores_invalid_resm_code(tmp_path):
+    """Invalid mutant residue codes should raise a README-linked error."""
+    test_df = pd.DataFrame({
+        'resn_col': ['ARG', 'THR'],
+        'resi_col': [1, 2],
+        'resm_col': ['ALA', 'STOP'],
+        'type_col': ['missense', 'stop'],
+        'effect_col': [0.5, -1.2],
+    })
+
+    test_file_path = os.path.join(tmp_path, 'test_invalid_resm.csv')
+    test_df.to_csv(test_file_path, index=False)
+
+    with pytest.raises(ValueError, match=r"Mutant residue column contains invalid codes: \['STOP'\].*README.md#mutation-input-requirements"):
+        load_mutation_scores(
+            path=test_file_path,
+            residue_col_name='resn_col',
+            residue_idx_name='resi_col',
+            mutation_col_name='resm_col',
+            mutation_type_col_name='type_col',
+            score_col_name='effect_col'
+        )
+
+
+def test_load_mutation_scores_invalid_type_raises_error(tmp_path):
+    """Unexpected mutation types should raise instead of warning."""
+    test_df = pd.DataFrame({
+        'resn_col': ['ARG', 'THR'],
+        'resi_col': [1, 2],
+        'resm_col': ['ALA', 'CYS'],
+        'type_col': ['missense', 'nonsense'],
+        'effect_col': [0.5, -1.2],
+    })
+
+    test_file_path = os.path.join(tmp_path, 'test_invalid_type.csv')
+    test_df.to_csv(test_file_path, index=False)
+
+    with pytest.raises(ValueError, match=r"Mutation type column contains invalid values: \['nonsense'\].*README.md#mutation-input-requirements"):
+        load_mutation_scores(
+            path=test_file_path,
+            residue_col_name='resn_col',
+            residue_idx_name='resi_col',
+            mutation_col_name='resm_col',
+            mutation_type_col_name='type_col',
+            score_col_name='effect_col'
+        )
+
+
+def test_load_mutation_scores_indel_type_raises_error(tmp_path):
+    """The broad indel type alias should be rejected in favor of insertion/deletion."""
+    test_df = pd.DataFrame({
+        'resn_col': ['ARG'],
+        'resi_col': [1],
+        'resm_col': ['DEL1'],
+        'type_col': ['indel'],
+        'effect_col': [0.5],
+    })
+
+    test_file_path = os.path.join(tmp_path, 'test_indel_type.csv')
+    test_df.to_csv(test_file_path, index=False)
+
+    with pytest.raises(ValueError, match=r"Mutation type column contains invalid values: \['indel'\].*README.md#mutation-input-requirements"):
+        load_mutation_scores(
+            path=test_file_path,
+            residue_col_name='resn_col',
+            residue_idx_name='resi_col',
+            mutation_col_name='resm_col',
+            mutation_type_col_name='type_col',
+            score_col_name='effect_col'
+        )
 
 
 def test_alignment_to_index_map():
@@ -213,7 +333,7 @@ def test_merge_mutation_scores(tmp_path):
         'resn': ['ARG', 'ARG', 'THR', 'THR', 'GLU', 'GLU', 'ASP'],
         'resi': [12, 12, 13, 13, 14, 14, 15],
         'resm': ['ALA', 'GLY', 'VAL', 'GLU', 'CYS', 'ASP', 'MET'],
-        'type': ['missense', 'missense', 'nonsense', 'missense', 'missense', 'nonsense', 'missense'],
+        'type': ['missense', 'missense', 'stop', 'missense', 'missense', 'stop', 'missense'],
         'effect': [0.5, -1.2, 0.3, -0.7, 1.0, -0.4, -0.1],
         'extra_col': [10, 20, 30, 40, 50, 60, 70]
     })
@@ -250,7 +370,7 @@ def test_merge_mutation_scores_row_order_invariant():
         'resn': ['ARG', 'ARG', 'THR', 'THR', 'GLU', 'GLU', 'ASP'],
         'resi': [12, 12, 13, 13, 14, 14, 15],
         'resm': ['ALA', 'GLY', 'VAL', 'GLU', 'CYS', 'ASP', 'MET'],
-        'type': ['missense', 'missense', 'nonsense', 'missense', 'missense', 'nonsense', 'missense'],
+        'type': ['missense', 'missense', 'stop', 'missense', 'missense', 'stop', 'missense'],
         'effect': [0.5, -1.2, 0.3, -0.7, 1.0, -0.4, -0.1],
         'extra_col': [10, 20, 30, 40, 50, 60, 70],
     })

--- a/tests/sequence/test_utils.py
+++ b/tests/sequence/test_utils.py
@@ -3,30 +3,35 @@ import warnings
 
 import pytest
 
-from src.sequence.utils import AA_1_TO_3, AA_3_TO_1, convert_amino_acid
+from src.sequence.utils import (
+    AA_1_TO_3,
+    AA_3_TO_1,
+    convert_amino_acid_1to3,
+    convert_amino_acid_3to1,
+)
 
 
 def test_convert_amino_acid_3_to_1():
     """Test conversion from 3-letter to 1-letter codes."""
-    assert convert_amino_acid("ALA") == "A"
-    assert convert_amino_acid("GLY") == "G"
-    assert convert_amino_acid("TRP") == "W"
-    assert convert_amino_acid("ala") == "A"  # case insensitive
+    assert convert_amino_acid_3to1("ALA") == "A"
+    assert convert_amino_acid_3to1("GLY") == "G"
+    assert convert_amino_acid_3to1("TRP") == "W"
+    assert convert_amino_acid_3to1("ala") == "A"  # case insensitive
 
 
 def test_convert_amino_acid_1_to_3():
     """Test conversion from 1-letter to 3-letter codes."""
-    assert convert_amino_acid("A") == "ALA"
-    assert convert_amino_acid("G") == "GLY"
-    assert convert_amino_acid("W") == "TRP"
-    assert convert_amino_acid("a") == "ALA"  # case insensitive
+    assert convert_amino_acid_1to3("A") == "ALA"
+    assert convert_amino_acid_1to3("G") == "GLY"
+    assert convert_amino_acid_1to3("W") == "TRP"
+    assert convert_amino_acid_1to3("a") == "ALA"  # case insensitive
 
 
-def test_convert_amino_acid_unknown_code():
+def test_convert_amino_acid_unknown_1letter_code():
     """Test that unknown codes return the input and issue a warning."""
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        result = convert_amino_acid("Z")
+        result = convert_amino_acid_1to3("Z")
         assert result == "Z"
         assert len(w) == 1
         assert "Unknown 1 letter code" in str(w[0].message)
@@ -34,7 +39,7 @@ def test_convert_amino_acid_unknown_code():
     # test with force_convert
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        result = convert_amino_acid("Z", force_convert=True)
+        result = convert_amino_acid_1to3("Z", force_convert=True)
         assert result == "ZZZ"
         assert len(w) == 1
         assert "Unknown 1 letter code" in str(w[0].message)
@@ -44,7 +49,7 @@ def test_convert_amino_acid_unknown_3letter_code():
     """Test that unknown 3-letter codes return the input and issue a warning."""
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        result = convert_amino_acid("XYZ")
+        result = convert_amino_acid_3to1("XYZ")
         assert result == "XYZ"
         assert len(w) == 1
         assert "Unknown 3 letter code" in str(w[0].message)
@@ -52,7 +57,7 @@ def test_convert_amino_acid_unknown_3letter_code():
     # test with force_convert
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        result = convert_amino_acid("XYZ", force_convert=True)
+        result = convert_amino_acid_3to1("XYZ", force_convert=True)
         assert result == "X"
         assert len(w) == 1
         assert "Unknown 3 letter code" in str(w[0].message)
@@ -62,28 +67,38 @@ def test_convert_amino_acid_unexpected_length():
     """Test that unexpected lengths return the input and issue a warning."""
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        result = convert_amino_acid("ALAA")
+        result = convert_amino_acid_3to1("ALAA")
         assert result == "ALAA"
         assert len(w) == 1
         assert "Unexpected amino acid code length" in str(w[0].message)
 
     # test with force_convert raises ValueError
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert convert_amino_acid_3to1("ALAA", force_convert=True) == "X"
+        assert len(w) == 1
+        assert "Unexpected amino acid code length" in str(w[0].message)
+
     with pytest.raises(ValueError):
-        convert_amino_acid("ALAA", force_convert=True)
+        convert_amino_acid_1to3("ALAA", force_convert=True)
 
 
 def test_convert_amino_acid_whitespace():
     """Test that whitespace is handled correctly."""
-    assert convert_amino_acid("  ALA  ") == "A"
-    assert convert_amino_acid("  A  ") == "ALA"
+    assert convert_amino_acid_3to1("  ALA  ") == "A"
+    assert convert_amino_acid_1to3("  A  ") == "ALA"
+
+
+def test_convert_amino_acid_special_mutation_tokens():
+    """Special mutant tokens should collapse to X in 3-to-1 conversion."""
+    for token in ["DEL", "DEL1", "DEL2", "DEL3", "INS1", "INS2", "INS3"]:
+        assert convert_amino_acid_3to1(token) == "X"
 
 
 def test_amino_acid_mappings_bidirectional():
-    """Test that the AA mappings are complete and bidirectional."""
-    # All 20 standard amino acids should be present
-    assert len(AA_3_TO_1) == 23
-    assert len(AA_1_TO_3) == 23
-    
-    # Bidirectionality
-    for three, one in AA_3_TO_1.items():
-        assert AA_1_TO_3[one] == three
+    """Test that canonical mappings stay consistent across both tables."""
+    assert len(AA_3_TO_1) == 28
+    assert len(AA_1_TO_3) == 21
+
+    for one, three in AA_1_TO_3.items():
+        assert AA_3_TO_1[three] == one


### PR DESCRIPTION
## Goal
Refactor amino acid conversion so directionality is explicit, and make mutation CSV validation fail fast against a documented input contract.

## Implementation
Split the old conversion helper into dedicated `1->3` and `3->1` functions, updated sequence alignment and sequence-metric call sites to use the correct direction, and added explicit loader validation for `resn`, `resm`, and canonical mutation `type` values. Extended the supported mutation-token handling so `DEL`, `DEL1-3`, and `INS1-3` are accepted mutant tokens and collapse to `X` when a single-character sequence representation is needed.

## Other areas
Updated the README with a `Mutation input requirements` section that loader errors reference directly, and added targeted tests for the new helper API, mixed mutant-token normalization, invalid residue/type inputs, and the narrowed mutation-type rules. Local verification included `ruff check src tests` and `pytest tests/ -v` in the worktree `.venv`.

Made with [Cursor](https://cursor.com)