### PR TITLE
Compute Kyte-Doolittle per residue at segment starts

### DIFF
--- a/src/metrics/structure.py
+++ b/src/metrics/structure.py
@@ -201,8 +201,7 @@ def calculate_kyte_doolittle(context: Context) -> pd.DataFrame:
         chain_mask = np.isin(array.chain_id, context.config.structural_feature_chains)
         array = array[chain_mask]
 
-    # One KD value per residue from residue name at segment starts (matches get_metadata_cols order).
-    # Avoids per-atom nanmean, which warns on all-NaN residues (e.g. unknown res names).
+    # Assign KD values per residue
     res_starts = struc.get_residue_starts(array)
     res_names = array.res_name[res_starts]
     kd_per_res = np.array(

--- a/src/metrics/structure.py
+++ b/src/metrics/structure.py
@@ -201,12 +201,15 @@ def calculate_kyte_doolittle(context: Context) -> pd.DataFrame:
         chain_mask = np.isin(array.chain_id, context.config.structural_feature_chains)
         array = array[chain_mask]
 
-    # Assign KD score per atom based on its residue name
-    atom_vals = np.array([kd_scale.get(rn.upper(), np.nan) for rn in array.res_name], dtype=float)
+    # One KD value per residue from residue name at segment starts (matches get_metadata_cols order).
+    # Avoids per-atom nanmean, which warns on all-NaN residues (e.g. unknown res names).
+    res_starts = struc.get_residue_starts(array)
+    res_names = array.res_name[res_starts]
+    kd_per_res = np.array(
+        [kd_scale.get(str(rn).strip().upper(), np.nan) for rn in res_names],
+        dtype=float,
+    )
 
-    # Collapse to per-residue (mean of identical values == the same value)
-    kd_per_res = struc.apply_residue_wise(array, atom_vals, function=np.nanmean)
-    
     # Attach to metadata DataFrame
     metadata_df = get_metadata_cols(array)
     metadata_df['kyte_doolittle'] = kd_per_res


### PR DESCRIPTION
## Goal

Kyte-Doolittle hydropathy is defined per residue type. The previous implementation assigned the same KD value to every atom, then used `apply_residue_wise(..., np.nanmean)` to collapse to one number per residue. For residues with unknown names (not in the KD table), every atom was NaN, so `np.nanmean` over that residue triggered NumPy's `RuntimeWarning: Mean of empty slice` even though the intended result was simply NaN.

## Implementation

- In `calculate_kyte_doolittle` (`src/metrics/structure.py`), build one value per residue using `get_residue_starts` and `res_name` at those indices, matching the row order of `get_metadata_cols`.
- Unknown residue types still map to NaN; no behavioral change for standard amino acids.

## Other areas

None.

## Testing

Full `pytest` (160 tests) and `ruff check` were run in the worktree before push.