### PR TITLE
Rename position effect quartiles metric to avg_effect_quartiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ It records:
 | Column | Description |
 |--------|-------------|
 | `effect` | Raw DMS effect score for this mutation |
-| `avg_effect` | Mean `effect` across non-synonymous mutations at this position (always recomputed) |
+| `avg_effect` | Mean `effect` across non-synonymous mutations at this position  |
 | `avg_effect_quartile` | Quartile label (`Q1`–`Q4`) from the distribution of `avg_effect` across positions |
 | `effect_variance` | Variance of effect scores at this position |
 | `effect_variance_rank` | Rank of effect variance among all positions |

--- a/README.md
+++ b/README.md
@@ -337,8 +337,8 @@ It records:
 | Column | Description |
 |--------|-------------|
 | `effect` | Raw DMS effect score for this mutation |
-| `pos_effect` | Mean effect score across all mutations at this position |
-| `effect_quartile` | Quartile of `pos_effect` (1 = lowest, 4 = highest) |
+| `avg_effect` | Mean `effect` across non-synonymous mutations at this position (always recomputed) |
+| `avg_effect_quartile` | Quartile label (`Q1`–`Q4`) from the distribution of `avg_effect` across positions |
 | `effect_variance` | Variance of effect scores at this position |
 | `effect_variance_rank` | Rank of effect variance among all positions |
 | `effect_ranking` | Rank of this specific mutation's effect score |

--- a/src/metrics/averaging_metrics.py
+++ b/src/metrics/averaging_metrics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 # Feature columns eligible for both ss-domain and neighborhood averaging.
 METRICS_TO_AVERAGE: list[str] = [
-    "pos_effect",
+    "avg_effect",
     "effect_variance",
     "effect_variance_rank",
     "effect",

--- a/src/metrics/sequence.py
+++ b/src/metrics/sequence.py
@@ -80,11 +80,11 @@ def make_phat75_73():
 
     return substitution_matrices.Array(alphabet=PHAT_ALPHABET, data=mat)
 
-@register_metric(name='position_effect_quartiles', provides=['effect_quartile', 'pos_effect'],
+@register_metric(name='avg_effect_quartiles', provides=['avg_effect_quartile', 'avg_effect'],
                  requires={'resm'}, tags={'sequence'})
-def calculate_position_effect_quartiles(context: Context, percentiles: Optional[List[float]] = None) -> pd.DataFrame:
+def calculate_avg_effect_quartiles(context: Context, percentiles: Optional[List[float]] = None) -> pd.DataFrame:
     """
-    Calculate quartiles of position effect scores.
+    Mean mutation effect per position (non-synonymous) and quartile labels from that distribution.
 
     Parameters
     ----------
@@ -96,14 +96,14 @@ def calculate_position_effect_quartiles(context: Context, percentiles: Optional[
     Returns
     -------
     pd.DataFrame
-        DataFrame with 'effect_quartile', 'pos_effect' along with residue metadata.
+        DataFrame with ``avg_effect_quartile``, ``avg_effect`` along with residue metadata.
 
     Raises
     ------
     ValueError
         If the residue table contains data from more than one chain.
     """
-    
+
     if percentiles is None:
         percentiles = [25, 50, 75]
     # subset to only include positions with mutation data
@@ -111,33 +111,22 @@ def calculate_position_effect_quartiles(context: Context, percentiles: Optional[
 
     # ensure that only a single chain is provided
     if len(seq_data.chain.unique()) > 1:
-        raise ValueError("calculate_position_effect_quartiles only supports single chain mutation data.")
+        raise ValueError("calculate_avg_effect_quartiles only supports single chain mutation data.")
 
-    # Determine if position effects are already calculated or need to be computed from data
-    if 'pos_effect' in seq_data.columns:
-        # exclude synonymous mutations, which have undefined position effects, and subset
-        pos_scores = seq_data[['resi_mut', 'pos_effect', 'type']]
-        pos_scores = pos_scores.loc[pos_scores.type != 'synonymous', ['resi_mut', 'pos_effect']]
-        pos_scores = pos_scores.drop_duplicates()
+    # Mean effect per position from non-synonymous mutations only (always recomputed from ``effect``).
+    pos_counts = seq_data[['resi_mut', 'effect', 'type']]
+    pos_counts = pos_counts.loc[pos_counts.type != 'synonymous', ['resi_mut', 'effect']]
+    pos_scores = pos_counts.groupby('resi_mut')['effect'].mean().reset_index()
+    pos_scores.rename(columns={'effect': 'avg_effect'}, inplace=True)
 
-    else:
-        # compute position effects from individual mutation effects, removing synonymous mutations
-        pos_counts = seq_data[['resi_mut', 'effect', 'type']]
-        pos_counts = pos_counts.loc[pos_counts.type != 'synonymous', ['resi_mut', 'effect']]
-        pos_scores = pos_counts.groupby('resi_mut')['effect'].mean().reset_index()
-        pos_scores.rename(columns={'effect': 'pos_effect'}, inplace=True)
+    cutoffs = np.percentile(pos_scores.avg_effect.dropna(), percentiles)
 
-    # define cutoffs for position effects
-    cutoffs = np.percentile(pos_scores.pos_effect.dropna(), percentiles)
-
-    # label positions based on quartiles
-    pos_scores['effect_quartile'] = pd.cut(
-        pos_scores['pos_effect'],
+    pos_scores['avg_effect_quartile'] = pd.cut(
+        pos_scores['avg_effect'],
         bins=[-np.inf, cutoffs[0], cutoffs[1], cutoffs[2], np.inf],
         labels=['Q1', 'Q2', 'Q3', 'Q4']
     )
 
-    # map quartile labels and raw effect scores back to original residues
     pos_scores = pd.merge(seq_data[KEEP_COLS], pos_scores, on='resi_mut', how='left')
 
     return pos_scores

--- a/src/metrics/sequence.py
+++ b/src/metrics/sequence.py
@@ -113,7 +113,7 @@ def calculate_avg_effect_quartiles(context: Context, percentiles: Optional[List[
     if len(seq_data.chain.unique()) > 1:
         raise ValueError("calculate_avg_effect_quartiles only supports single chain mutation data.")
 
-    # Mean effect per position from non-synonymous mutations only (always recomputed from ``effect``).
+    # Mean effect per position from non-synonymous mutations.
     pos_counts = seq_data[['resi_mut', 'effect', 'type']]
     pos_counts = pos_counts.loc[pos_counts.type != 'synonymous', ['resi_mut', 'effect']]
     pos_scores = pos_counts.groupby('resi_mut')['effect'].mean().reset_index()

--- a/tests/metrics/test_sequence.py
+++ b/tests/metrics/test_sequence.py
@@ -15,9 +15,7 @@ np.random.seed(42)
 random.seed(42)
 
 
-def test_calculate_position_effect_quartiles_with_pos_effect():
-
-    # create test residue table with pos_effect column
+def test_calculate_avg_effect_quartiles_basic():
     residue_table = _make_residue_table(num_residues=10, num_chains=1, make_muts=True)
 
     # remove mutation data for last residue to test handling of missing data
@@ -26,53 +24,46 @@ def test_calculate_position_effect_quartiles_with_pos_effect():
                             'effect': [np.nan], 'type': [np.nan], 'struct_info': [True], 'mut_info': [False]})
     residue_table = pd.concat([residue_table, new_row], ignore_index=True)
 
-    # compute position effects
-    pos_effects = residue_table.groupby('resi_mut')['effect'].mean().reset_index()
-    pos_effects.rename(columns={'effect': 'pos_effect'}, inplace=True)
-    residue_table = pd.merge(residue_table, pos_effects, on='resi_mut', how='left')
-
-    # create mock context
     class MockContext:
         def __init__(self, residue_table):
             self.residue_table = residue_table
+
     context = MockContext(residue_table)
 
-    # calculate quartiles
-    quartile_df = metrics.calculate_position_effect_quartiles(context)
+    quartile_df = metrics.calculate_avg_effect_quartiles(context)
 
-    # check that quartile labels are correct
-    assert 'effect_quartile' in quartile_df.columns
-    assert set(quartile_df['effect_quartile'].dropna().unique()).issubset({'Q1', 'Q2', 'Q3', 'Q4'})
+    assert 'avg_effect_quartile' in quartile_df.columns
+    assert 'avg_effect' in quartile_df.columns
+    assert set(quartile_df['avg_effect_quartile'].dropna().unique()).issubset({'Q1', 'Q2', 'Q3', 'Q4'})
     assert 10 not in quartile_df.resi_mut.values
 
 
-def test_calculate_position_effect_quartiles_without_pos_effect():
-    # create test residue table without pos_effect column
+def test_calculate_avg_effect_quartiles_ignores_stale_pos_effect_column():
+    """Precomputed ``pos_effect`` on the residue table must not replace recomputed ``avg_effect``."""
     residue_table = _make_residue_table(num_residues=10, num_chains=1, make_muts=True)
+    residue_table['pos_effect'] = 999.0
 
-    # remove mutation data for last residue to test handling of missing data
-    residue_table = residue_table[residue_table['resi_mut'] != 10]
-    new_row = pd.DataFrame({'chain': ['A'], 'resi_mut': [10], 'resn_mut': ['ALA'], 'resi_struct': [10], 'resn_struct': ['ALA'], 'resm': [np.nan],
-                            'effect': [np.nan], 'type': [np.nan], 'struct_info': [True], 'mut_info': [False]})
-    residue_table = pd.concat([residue_table, new_row], ignore_index=True)
-
-    # create mock context
     class MockContext:
         def __init__(self, residue_table):
             self.residue_table = residue_table
 
     context = MockContext(residue_table)
+    out = metrics.calculate_avg_effect_quartiles(context)
 
-    # calculate quartiles
-    quartile_df = metrics.calculate_position_effect_quartiles(context)
+    mut = residue_table.loc[residue_table.mut_info]
+    non_syn = mut.loc[mut['type'] != 'synonymous']
+    expected_by_pos = non_syn.groupby('resi_mut', sort=False)['effect'].mean()
 
-    # check that quartile labels are correct
-    assert 'effect_quartile' in quartile_df.columns
-    assert set(quartile_df['effect_quartile'].dropna().unique()).issubset({'Q1', 'Q2', 'Q3', 'Q4'})
-    assert 10 not in quartile_df.resi_mut.values
+    for resi in out['resi_mut'].unique():
+        got = out.loc[out['resi_mut'] == resi, 'avg_effect'].dropna().unique()
+        if resi not in expected_by_pos.index:
+            assert len(got) == 0
+            continue
+        assert len(got) == 1
+        assert got[0] == expected_by_pos[resi]
 
 
-def test_calculate_position_effect_quartiles_custom_percentiles():
+def test_calculate_avg_effect_quartiles_custom_percentiles():
     """Test that custom percentiles produce different quartile assignments than defaults."""
     # create test residue table
     residue_table = _make_residue_table(num_residues=10, num_chains=1, make_muts=True)
@@ -84,23 +75,23 @@ def test_calculate_position_effect_quartiles_custom_percentiles():
     context = MockContext(residue_table)
 
     # Get results with default percentiles
-    default_df = metrics.calculate_position_effect_quartiles(context)
+    default_df = metrics.calculate_avg_effect_quartiles(context)
 
     # Use extreme custom percentiles - with [90, 95, 99], most values fall below the 90th percentile, ending up in Q1
     custom_percentiles = [90, 95, 99]
-    custom_df = metrics.calculate_position_effect_quartiles(context, percentiles=custom_percentiles)
+    custom_df = metrics.calculate_avg_effect_quartiles(context, percentiles=custom_percentiles)
 
-    assert 'effect_quartile' in custom_df.columns
-    assert set(custom_df['effect_quartile'].dropna().unique()).issubset({'Q1', 'Q2', 'Q3', 'Q4'})
+    assert 'avg_effect_quartile' in custom_df.columns
+    assert set(custom_df['avg_effect_quartile'].dropna().unique()).issubset({'Q1', 'Q2', 'Q3', 'Q4'})
 
     # With extreme percentiles, the distribution should be different from default
-    default_q1_count = (default_df['effect_quartile'] == 'Q1').sum()
-    custom_q1_count = (custom_df['effect_quartile'] == 'Q1').sum()
+    default_q1_count = (default_df['avg_effect_quartile'] == 'Q1').sum()
+    custom_q1_count = (custom_df['avg_effect_quartile'] == 'Q1').sum()
     # With [90, 95, 99] cutoffs, most values should fall into Q1
     assert custom_q1_count > default_q1_count
 
 
-def test_calculate_position_effect_quartiles_multichain_error():
+def test_calculate_avg_effect_quartiles_multichain_error():
     """Test that ValueError is raised when residue table contains data from more than one chain."""
     # Create test residue table with multiple chains
     residue_table = _make_residue_table(num_residues=5, num_chains=2, make_muts=True)
@@ -112,8 +103,8 @@ def test_calculate_position_effect_quartiles_multichain_error():
     context = MockContext(residue_table)
 
     # Verify that ValueError is raised with appropriate message
-    with pytest.raises(ValueError, match="calculate_position_effect_quartiles only supports single chain mutation data"):
-        metrics.calculate_position_effect_quartiles(context)
+    with pytest.raises(ValueError, match="calculate_avg_effect_quartiles only supports single chain mutation data"):
+        metrics.calculate_avg_effect_quartiles(context)
 
 
 def test_calculate_effect_variance():

--- a/tests/metrics/test_sequence.py
+++ b/tests/metrics/test_sequence.py
@@ -38,31 +38,6 @@ def test_calculate_avg_effect_quartiles_basic():
     assert 10 not in quartile_df.resi_mut.values
 
 
-def test_calculate_avg_effect_quartiles_ignores_stale_pos_effect_column():
-    """Precomputed ``pos_effect`` on the residue table must not replace recomputed ``avg_effect``."""
-    residue_table = _make_residue_table(num_residues=10, num_chains=1, make_muts=True)
-    residue_table['pos_effect'] = 999.0
-
-    class MockContext:
-        def __init__(self, residue_table):
-            self.residue_table = residue_table
-
-    context = MockContext(residue_table)
-    out = metrics.calculate_avg_effect_quartiles(context)
-
-    mut = residue_table.loc[residue_table.mut_info]
-    non_syn = mut.loc[mut['type'] != 'synonymous']
-    expected_by_pos = non_syn.groupby('resi_mut', sort=False)['effect'].mean()
-
-    for resi in out['resi_mut'].unique():
-        got = out.loc[out['resi_mut'] == resi, 'avg_effect'].dropna().unique()
-        if resi not in expected_by_pos.index:
-            assert len(got) == 0
-            continue
-        assert len(got) == 1
-        assert got[0] == expected_by_pos[resi]
-
-
 def test_calculate_avg_effect_quartiles_custom_percentiles():
     """Test that custom percentiles produce different quartile assignments than defaults."""
     # create test residue table

--- a/tests/pipeline/test_sequence_window_features.py
+++ b/tests/pipeline/test_sequence_window_features.py
@@ -26,7 +26,7 @@ def test_calculate_sequence_window_features_collapses_and_rolls():
             "effect": [2.0, 4.0, 4.0, 6.0, 6.0, 8.0, np.nan, np.nan, 10.0, 12.0, 12.0, 14.0],
             "blosum90": [1.0, 3.0, 2.0, 4.0, 3.0, 5.0, np.nan, np.nan, 5.0, 7.0, 6.0, 8.0],
             "AA1_hydrophobicity_mut": [10.0, 14.0, 20.0, 24.0, 30.0, 34.0, np.nan, np.nan, 50.0, 54.0, 60.0, 64.0],
-            "effect_quartile": ["Q1", "Q1", "Q2", "Q2", "Q3", "Q3", None, None, "Q4", "Q4", "Q4", "Q4"],
+            "avg_effect_quartile": ["Q1", "Q1", "Q2", "Q2", "Q3", "Q3", None, None, "Q4", "Q4", "Q4", "Q4"],
             "mut_aa_group": ["A", "B", "A", "B", "A", "B", None, None, "A", "B", "A", "B"],
         }
     )
@@ -38,7 +38,7 @@ def test_calculate_sequence_window_features_collapses_and_rolls():
             "effect",
             "blosum90",
             "AA1_hydrophobicity_mut",
-            "effect_quartile",
+            "avg_effect_quartile",
             "mut_aa_group",
         ],
         window_size=5,
@@ -46,7 +46,7 @@ def test_calculate_sequence_window_features_collapses_and_rolls():
 
     assert len(result) == 5
     assert ("A", 4, "ASP") not in result.index
-    assert "sequence_window_effect_quartile" not in result.columns
+    assert "sequence_window_avg_effect_quartile" not in result.columns
     assert "sequence_window_mut_aa_group" not in result.columns
     assert "sequence_window_AA1_hydrophobicity_mut" in result.columns
 
@@ -74,14 +74,14 @@ def test_calculate_sequence_window_features_returns_empty_without_numeric_metric
             "chain": ["A"],
             "resi_mut": [1],
             "resn_mut": ["ALA"],
-            "effect_quartile": ["Q1"],
+            "avg_effect_quartile": ["Q1"],
         }
     )
 
     result = calculate_sequence_window_features(
         DummyContext(residue_table),
         features,
-        seq_metric_columns=["effect_quartile"],
+        seq_metric_columns=["avg_effect_quartile"],
         window_size=5,
     )
 


### PR DESCRIPTION
- Always compute avg_effect from non-synonymous mutation effect means
- Remove legacy branch that reused a pos_effect column on residue_table
- Rename outputs: avg_effect, avg_effect_quartile; METRICS_TO_AVERAGE entry
- Update README and tests

Made-with: Cursor