### PR TITLE
Add mutation type to features and de-bias synonymous aggregates

### DIFF
--- a/src/metrics/neighborhood_metrics.py
+++ b/src/metrics/neighborhood_metrics.py
@@ -19,6 +19,13 @@ from src.pipeline.context import Context
 from src.structure.utils import res_key
 
 STRUCT_COLS = ["chain", "resi_struct", "resn_struct"]
+NONSYN_NEIGHBOR_COLUMNS = {
+    "avg_effect",
+    "effect_variance",
+    "effect_variance_rank",
+    "effect",
+    "effect_ranking",
+}
 
 
 def count_ala_neighbors(
@@ -154,10 +161,17 @@ def average_neighbor_metrics(
     present_metrics = [c for c in METRICS_TO_AVERAGE if c in features.columns]
     
     # Collapse mutation-level rows to one residue-level row by averaging each metric per residue.
+    selection_cols = STRUCT_COLS + present_metrics + ["type"]
     residue_level = features.loc[
         features["resi_struct"].notna(),
-        STRUCT_COLS + present_metrics,
+        selection_cols,
     ].copy()
+
+    synonymous_mask = residue_level["type"].eq("synonymous")
+    for metric in present_metrics:
+        if metric in NONSYN_NEIGHBOR_COLUMNS:
+            residue_level.loc[synonymous_mask, metric] = float("nan")
+    residue_level = residue_level.drop(columns=["type"])
     residue_level = residue_level.groupby(STRUCT_COLS, as_index=False).agg(
         {metric: "mean" for metric in present_metrics}
     )

--- a/src/metrics/neighborhood_metrics.py
+++ b/src/metrics/neighborhood_metrics.py
@@ -161,17 +161,18 @@ def average_neighbor_metrics(
     present_metrics = [c for c in METRICS_TO_AVERAGE if c in features.columns]
     
     # Collapse mutation-level rows to one residue-level row by averaging each metric per residue.
-    selection_cols = STRUCT_COLS + present_metrics + ["type"]
+    selection_cols = STRUCT_COLS + present_metrics + (["type"] if "type" in features.columns else [])
     residue_level = features.loc[
         features["resi_struct"].notna(),
         selection_cols,
     ].copy()
 
-    synonymous_mask = residue_level["type"].eq("synonymous")
-    for metric in present_metrics:
-        if metric in NONSYN_NEIGHBOR_COLUMNS:
-            residue_level.loc[synonymous_mask, metric] = float("nan")
-    residue_level = residue_level.drop(columns=["type"])
+    if "type" in residue_level.columns:
+        synonymous_mask = residue_level["type"].eq("synonymous")
+        for metric in present_metrics:
+            if metric in NONSYN_NEIGHBOR_COLUMNS:
+                residue_level.loc[synonymous_mask, metric] = float("nan")
+        residue_level = residue_level.drop(columns=["type"])
     residue_level = residue_level.groupby(STRUCT_COLS, as_index=False).agg(
         {metric: "mean" for metric in present_metrics}
     )

--- a/src/metrics/sequence.py
+++ b/src/metrics/sequence.py
@@ -25,6 +25,16 @@ logger = logging.getLogger(__name__)
 KEEP_COLS = ['chain', 'resi_mut', 'resn_mut', 'resm']
 
 
+def _mutation_rows(context: Context) -> pd.DataFrame:
+    """Rows carrying mutation context from the merged residue table."""
+    return context.residue_table.loc[context.residue_table.mut_info, :].copy()
+
+
+def _exclude_synonymous(rows: pd.DataFrame) -> pd.DataFrame:
+    """Exclude synonymous rows when mutation type is available."""
+    return rows.loc[rows['type'] != 'synonymous', :].copy()
+
+
 def _empty_mutation_category_frame(seq_data: pd.DataFrame) -> pd.DataFrame:
     keep_cols = [col for col in KEEP_COLS if col in seq_data.columns]
     empty = seq_data[keep_cols].copy()
@@ -107,7 +117,7 @@ def calculate_avg_effect_quartiles(context: Context, percentiles: Optional[List[
     if percentiles is None:
         percentiles = [25, 50, 75]
     # subset to only include positions with mutation data
-    seq_data = context.residue_table.loc[context.residue_table.mut_info, :]
+    seq_data = _mutation_rows(context)
 
     # ensure that only a single chain is provided
     if len(seq_data.chain.unique()) > 1:
@@ -149,7 +159,7 @@ def calculate_effect_variance(context: Context) -> pd.DataFrame:
     """
     
     # Calculate SEM for each position from rows that actually have mutation context.
-    seq_data = context.residue_table.loc[context.residue_table.mut_info, :].copy()
+    seq_data = _exclude_synonymous(_mutation_rows(context))
     position_cols = ['chain', 'resi_mut', 'resn_mut']
     effect_variance = (
         seq_data
@@ -191,14 +201,16 @@ def calculate_effect_ranking(context: Context) -> pd.DataFrame:
     """
     
     # Calculate ranking for each position
-    effect_ranking = context.residue_table.loc[context.residue_table.mut_info, :]
+    all_mutations = _mutation_rows(context)
+    nonsyn = _exclude_synonymous(all_mutations)
     keep_cols = [col for col in KEEP_COLS if col in context.residue_table.columns]
-    effect_ranking = effect_ranking[keep_cols + ['effect']]
 
-    effect_ranking['effect_ranking'] = effect_ranking['effect'].rank(method='min')
-    effect_ranking['effect_ranking'] = effect_ranking['effect_ranking'] / np.max(effect_ranking['effect_ranking'])
-    
-    return effect_ranking
+    ranked = nonsyn[keep_cols + ['effect']].copy()
+    ranked['effect_ranking'] = ranked['effect'].rank(method='min')
+    ranked['effect_ranking'] = ranked['effect_ranking'] / np.max(ranked['effect_ranking'])
+
+    # Preserve all mutation rows; synonymous rows remain NaN for effect/effect_ranking.
+    return pd.merge(all_mutations[keep_cols], ranked, on=keep_cols, how='left')
 
 
 @register_metric(
@@ -213,7 +225,7 @@ def calculate_mutation_category(context: Context) -> pd.DataFrame:
     Synonymous effects use a mixture-sampled equal-tail interval; stop effects use the lower-mean
     component when well-separated, otherwise the combined mixture.
     """
-    seq_data = context.residue_table.loc[context.residue_table.mut_info, :].copy()
+    seq_data = _mutation_rows(context)
 
     central_interval = MUTATION_CATEGORY_CENTRAL_INTERVAL
     fit = fit_mutation_category_reference(seq_data, central_interval)
@@ -235,9 +247,12 @@ def calculate_mutation_category(context: Context) -> pd.DataFrame:
     mutation_categories['mutation_category'] = mutation_category
 
     position_cols = ['chain', 'resi_mut', 'resn_mut']
-    position_counts = seq_data[position_cols].copy()
-    position_counts['total_lof'] = mutation_category.eq('LOF').fillna(False).astype(int)
-    position_counts['total_gof'] = mutation_category.eq('GOF').fillna(False).astype(int)
+    count_rows = seq_data[position_cols + ['type']].copy()
+    count_mask = count_rows['type'] != 'synonymous'
+    
+    position_counts = count_rows[position_cols].copy()
+    position_counts['total_lof'] = (mutation_category.eq('LOF') & count_mask).fillna(False).astype(int)
+    position_counts['total_gof'] = (mutation_category.eq('GOF') & count_mask).fillna(False).astype(int)
     position_counts = (
         position_counts
         .groupby(position_cols, dropna=False)[['total_lof', 'total_gof']]

--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -396,7 +396,16 @@ class Runner:
         """
         # Get all unique rows to merge on
 
-        potential_cols = ['chain', 'resi_struct', 'resn_struct', 'resi_mut', 'resn_mut', 'align_pos']
+        potential_cols = [
+            'chain',
+            'resi_struct',
+            'resn_struct',
+            'resi_mut',
+            'resn_mut',
+            'type',
+            'ss_group',
+            'align_pos',
+        ]
         keep_cols = [col for col in potential_cols if col in self.context.residue_table.columns]
 
         # Add mutation columns if mutations are present

--- a/src/pipeline/secondary_structure_features.py
+++ b/src/pipeline/secondary_structure_features.py
@@ -6,6 +6,14 @@ from src.metrics.averaging_metrics import METRICS_TO_AVERAGE
 from src.metrics.secondary_structure import ss_domain_lengths, ss_domain_log2_aa_group_ratios
 from src.pipeline.context import Context
 
+NONSYN_DOMAIN_COLUMNS = {
+    "avg_effect",
+    "effect_variance",
+    "effect_variance_rank",
+    "effect",
+    "effect_ranking",
+}
+
 
 def calculate_secondary_structure_features(
     context: Context,
@@ -19,6 +27,12 @@ def calculate_secondary_structure_features(
     rt_subset = context.residue_table[merge_cols + ["ss_domains"]].drop_duplicates(merge_cols)
     merged = pd.merge(features, rt_subset, on=merge_cols, how="left")
     merged = merged.dropna(subset=["ss_domains"])
+
+    # Exclude synonymous rows from calculations
+    synonymous_mask = merged["type"].eq("synonymous")
+    for column in NONSYN_DOMAIN_COLUMNS:
+        if column in merged.columns:
+            merged.loc[synonymous_mask, column] = float("nan")
 
     cols_to_avg = [column for column in metrics_to_avg if column in merged.columns]
 

--- a/src/pipeline/secondary_structure_features.py
+++ b/src/pipeline/secondary_structure_features.py
@@ -28,11 +28,12 @@ def calculate_secondary_structure_features(
     merged = pd.merge(features, rt_subset, on=merge_cols, how="left")
     merged = merged.dropna(subset=["ss_domains"])
 
-    # Exclude synonymous rows from calculations
-    synonymous_mask = merged["type"].eq("synonymous")
-    for column in NONSYN_DOMAIN_COLUMNS:
-        if column in merged.columns:
-            merged.loc[synonymous_mask, column] = float("nan")
+    # Exclude synonymous rows from calculations when mutation type context is present.
+    if "type" in merged.columns:
+        synonymous_mask = merged["type"].eq("synonymous")
+        for column in NONSYN_DOMAIN_COLUMNS:
+            if column in merged.columns:
+                merged.loc[synonymous_mask, column] = float("nan")
 
     cols_to_avg = [column for column in metrics_to_avg if column in merged.columns]
 

--- a/src/pipeline/sequence_window_features.py
+++ b/src/pipeline/sequence_window_features.py
@@ -8,6 +8,13 @@ from pandas.api.types import is_bool_dtype, is_numeric_dtype
 from src.pipeline.context import Context
 
 SEQUENCE_MERGE_COLS = ["chain", "resi_mut", "resn_mut"]
+NONSYN_WINDOW_COLUMNS = {
+    "avg_effect",
+    "effect_variance",
+    "effect_variance_rank",
+    "effect",
+    "effect_ranking",
+}
 
 
 def calculate_sequence_window_features(
@@ -70,6 +77,20 @@ def calculate_sequence_window_features(
         how="left",
         validate="many_to_one",
     )
+    # Exclude synonymous rows from calculations
+    type_lookup = features[SEQUENCE_MERGE_COLS + ["type"]].drop_duplicates(SEQUENCE_MERGE_COLS)
+    residue_level = pd.merge(
+        residue_level,
+        type_lookup,
+        on=SEQUENCE_MERGE_COLS,
+        how="left",
+        validate="many_to_one",
+    )
+    synonymous_mask = residue_level["type"].eq("synonymous")
+    for column in numeric_cols:
+        if column in NONSYN_WINDOW_COLUMNS:
+            residue_level.loc[synonymous_mask, column] = float("nan")
+    residue_level = residue_level.drop(columns=["type"])
     # Residue-level inputs for the window come from the mean across mutation rows.
     residue_level = residue_level.groupby(
         SEQUENCE_MERGE_COLS + ["align_pos"],

--- a/src/pipeline/sequence_window_features.py
+++ b/src/pipeline/sequence_window_features.py
@@ -70,29 +70,23 @@ def calculate_sequence_window_features(
         .drop_duplicates(SEQUENCE_MERGE_COLS)
         .reset_index(drop=True)
     )
-    residue_level = pd.merge(
-        features[SEQUENCE_MERGE_COLS + numeric_cols],
+    mutation_level_cols = SEQUENCE_MERGE_COLS + numeric_cols + (["type"] if "type" in features.columns else [])
+    mutation_level = pd.merge(
+        features[mutation_level_cols],
         align_pos,
         on=SEQUENCE_MERGE_COLS,
         how="left",
         validate="many_to_one",
     )
-    # Exclude synonymous rows from calculations
-    type_lookup = features[SEQUENCE_MERGE_COLS + ["type"]].drop_duplicates(SEQUENCE_MERGE_COLS)
-    residue_level = pd.merge(
-        residue_level,
-        type_lookup,
-        on=SEQUENCE_MERGE_COLS,
-        how="left",
-        validate="many_to_one",
-    )
-    synonymous_mask = residue_level["type"].eq("synonymous")
-    for column in numeric_cols:
-        if column in NONSYN_WINDOW_COLUMNS:
-            residue_level.loc[synonymous_mask, column] = float("nan")
-    residue_level = residue_level.drop(columns=["type"])
+    # Exclude synonymous rows from calculations when mutation type context is present.
+    if "type" in mutation_level.columns:
+        synonymous_mask = mutation_level["type"].eq("synonymous")
+        for column in numeric_cols:
+            if column in NONSYN_WINDOW_COLUMNS:
+                mutation_level.loc[synonymous_mask, column] = float("nan")
+        mutation_level = mutation_level.drop(columns=["type"])
     # Residue-level inputs for the window come from the mean across mutation rows.
-    residue_level = residue_level.groupby(
+    residue_level = mutation_level.groupby(
         SEQUENCE_MERGE_COLS + ["align_pos"],
         as_index=False,
     ).agg({column: "mean" for column in numeric_cols})

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -618,8 +618,9 @@ def test_runner_run_metric(tmp_path):
             'resm',
             'type',
             'name',
-            'ss_group'
         ]
+        if 'ss_group' in myrunner.context.residue_table.columns:
+            expected_cols.append('ss_group')
 
         if metric == 'aaindex_scores':
             for _, r in aaindex_data.iterrows():

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -609,7 +609,17 @@ def test_runner_run_metric(tmp_path):
         returned_features = myrunner.run_metrics(metrics=[metric], mutations=True)
 
         returned_cols = returned_features.columns.tolist()
-        expected_cols = ['chain', 'resi_mut', 'resn_mut', 'resi_struct', 'resn_struct', 'resm', 'name']
+        expected_cols = [
+            'chain',
+            'resi_mut',
+            'resn_mut',
+            'resi_struct',
+            'resn_struct',
+            'resm',
+            'type',
+            'name',
+            'ss_group'
+        ]
 
         if metric == 'aaindex_scores':
             for _, r in aaindex_data.iterrows():


### PR DESCRIPTION
## Goal
Expose mutation type context in the features output and reduce bias from synonymous variants in mutation-aggregated effect metrics.

## Implementation
- Carried type and ss_group into the features merge base in Runner._merge_features() while leaving save_results() metadata export unchanged.
- Added non-synonymous filtering logic for effect-derived aggregations:
  - effect_variance
  - effect_ranking (synonymous rows are retained but effect-derived fields are left null)
  - mutation_category position-level LOF/GOF counts
  - sequence-window effect aggregates
  - secondary-structure-domain effect aggregates
  - neighborhood effect aggregates
- Updated tests/pipeline/test_runner.py expected columns for the new features schema.

## Other areas
None.

## Test plan
- ruff check src tests
- pytest tests/metrics/test_sequence.py tests/pipeline/test_runner.py tests/pipeline/test_examples.py -q
- pytest -q