### PR TITLE
Replace pooled-metrics whitelist with exclude resolver and sequence-window cutoff

### DIFF
--- a/src/metrics/averaging_metrics.py
+++ b/src/metrics/averaging_metrics.py
@@ -1,27 +1,134 @@
-"""Shared metric lists used by averaging integrations."""
+"""Shared rules for spatial pooling (neighbor + SS domain) and sequence-window inputs."""
 
 from __future__ import annotations
 
-# Feature columns eligible for both ss-domain and neighborhood averaging.
-METRICS_TO_AVERAGE: list[str] = [
-    "avg_effect",
-    "effect_variance",
-    "effect_variance_rank",
-    "effect",
-    "effect_ranking",
-    "sasa",
-    "sasa_backbone",
-    "sasa_sidechain",
-    "sasa_polar",
-    "sasa_nonpolar",
-    "kyte_doolittle",
-    "distance_from_membrane_edge",
-    "bb_hbond_count",
-    "sc_hbond_count",
-    "total_hbond_count",
-    "packing_n_atoms",
-    "packing_n_neighbor_residues",
-    "packing_contact_density",
-    "blosum90",
-    "phat_score",
-]
+import pandas as pd
+from pandas.api.types import is_bool_dtype, is_numeric_dtype
+
+# Columns that are never pooled (merge keys, labels, config echo, derived SS label on row).
+NON_METRIC_COLUMNS: frozenset[str] = frozenset(
+    {
+        "chain",
+        "resi_struct",
+        "resn_struct",
+        "resi_mut",
+        "resn_mut",
+        "resm",
+        "type",
+        "name",
+        "align_pos",
+        "ss_group",
+        "struct_info",
+        "mut_info",
+        "ss_domains",
+    }
+)
+
+# Explicit spatial-pool excludes: mutation typing, AA groups, ordinal labels, high-dim biochem.
+METRICS_EXCLUDED_FROM_SPATIAL_POOLING: frozenset[str] = frozenset(
+    {
+        "mutation_category",
+        "total_lof",
+        "total_gof",
+        "avg_effect_quartile",
+        "wildtype_aa_group",
+        "mut_aa_group",
+        "wildtype_mut_aa_group",
+    }
+)
+
+# Registry gaps: experiment readout columns not always marked requires={'resm'}.
+MUTATION_READOUT_COLUMNS: frozenset[str] = frozenset(
+    {
+        "effect",
+        "effect_variance",
+        "effect_variance_rank",
+        "effect_ranking",
+    }
+)
+
+_DERIVED_OUTPUT_PREFIXES: tuple[str, ...] = (
+    "neighborhood_",
+    "ss_domain_",
+    "sequence_window_",
+    "ligand_",
+    "graph_",
+)
+
+
+_resm_provides_columns_cache: frozenset[str] | None = None
+
+
+def resm_dependent_metric_columns_from_registry() -> frozenset[str]:
+    """Column names supplied by metrics that declare dependency on ``resm``."""
+    global _resm_provides_columns_cache
+    if _resm_provides_columns_cache is None:
+        import src.metrics.bonds  # noqa: F401 — register metric modules before reading registry
+        import src.metrics.sequence  # noqa: F401
+        import src.metrics.structure  # noqa: F401
+        from src.metrics.registry import _REGISTRY
+
+        names: set[str] = set()
+        for meta, _ in _REGISTRY.values():
+            if "resm" in meta.requires:
+                names.update(meta.provides)
+        _resm_provides_columns_cache = frozenset(names)
+    return _resm_provides_columns_cache
+
+
+def column_needs_synonym_mask(column: str) -> bool:
+    """True if pooled values for synonymous mutation rows must be suppressed (NaN)."""
+    if column in MUTATION_READOUT_COLUMNS:
+        return True
+    if column in resm_dependent_metric_columns_from_registry():
+        return True
+    if column.endswith(("_mut", "_diff")):
+        return True
+    return False
+
+
+def _is_derived_metric_column(name: str) -> bool:
+    return any(name.startswith(prefix) for prefix in _DERIVED_OUTPUT_PREFIXES)
+
+
+def _excluded_biochemical_patterns(name: str) -> bool:
+    if name.startswith("kidera_"):
+        return True
+    if name.endswith("_wt") or name.endswith("_mut") or name.endswith("_diff"):
+        return True
+    return False
+
+
+def spatial_pool_metric_columns(features: pd.DataFrame) -> list[str]:
+    """Columns eligible for neighbor + SS-domain pooling: exclude metadata, labels, and high-dim biochem."""
+    out: list[str] = []
+    for column in sorted(features.columns):
+        if column in NON_METRIC_COLUMNS:
+            continue
+        if column in METRICS_EXCLUDED_FROM_SPATIAL_POOLING:
+            continue
+        if _is_derived_metric_column(column):
+            continue
+        if _excluded_biochemical_patterns(column):
+            continue
+        out.append(column)
+    return out
+
+
+def assert_poolable_numeric_columns(columns: list[str], features: pd.DataFrame) -> None:
+    """Raise ValueError if any listed column is missing or not poolable numeric (exclude bool)."""
+    bad: list[tuple[str, str]] = []
+    for column in columns:
+        if column not in features.columns:
+            bad.append((column, "missing"))
+            continue
+        series = features[column]
+        if is_bool_dtype(series):
+            bad.append((column, "bool"))
+        elif not is_numeric_dtype(series):
+            bad.append((column, str(series.dtype)))
+    if bad:
+        detail = "; ".join(f"{c} ({reason})" for c, reason in bad)
+        raise ValueError(
+            "Neighborhood averaging requires poolable numeric columns (non-boolean). Offending: " + detail
+        )

--- a/src/metrics/neighborhood_metrics.py
+++ b/src/metrics/neighborhood_metrics.py
@@ -13,19 +13,16 @@ from collections import Counter
 
 import pandas as pd
 
-from src.metrics.averaging_metrics import METRICS_TO_AVERAGE
+from src.metrics.averaging_metrics import (
+    assert_poolable_numeric_columns,
+    column_needs_synonym_mask,
+    spatial_pool_metric_columns,
+)
 from src.metrics.secondary_structure import AA_TO_GROUP
 from src.pipeline.context import Context
 from src.structure.utils import res_key
 
 STRUCT_COLS = ["chain", "resi_struct", "resn_struct"]
-NONSYN_NEIGHBOR_COLUMNS = {
-    "avg_effect",
-    "effect_variance",
-    "effect_variance_rank",
-    "effect",
-    "effect_ranking",
-}
 
 
 def count_ala_neighbors(
@@ -143,7 +140,7 @@ def average_neighbor_metrics(
     """Average selected feature columns across each residue's 3D neighborhood.
 
     Uses context.extras['residue_neighbors'] (residue_key -> [neighbor keys]).
-    Only columns listed in METRICS_TO_AVERAGE and present in features are averaged.
+    Columns are chosen via ``spatial_pool_metric_columns(features)``; non-numeric dtypes raise.
     Output columns are prefixed with ``neighborhood_``.
 
     Parameters
@@ -158,8 +155,9 @@ def average_neighbor_metrics(
         Columns: chain, resi_struct, resn_struct, and neighborhood_<metric> columns.
     """
     neighbor_map = context.extras["residue_neighbors"]
-    present_metrics = [c for c in METRICS_TO_AVERAGE if c in features.columns]
-    
+    present_metrics = spatial_pool_metric_columns(features)
+    assert_poolable_numeric_columns(present_metrics, features)
+
     # Collapse mutation-level rows to one residue-level row by averaging each metric per residue.
     selection_cols = STRUCT_COLS + present_metrics + (["type"] if "type" in features.columns else [])
     residue_level = features.loc[
@@ -170,7 +168,7 @@ def average_neighbor_metrics(
     if "type" in residue_level.columns:
         synonymous_mask = residue_level["type"].eq("synonymous")
         for metric in present_metrics:
-            if metric in NONSYN_NEIGHBOR_COLUMNS:
+            if column_needs_synonym_mask(metric):
                 residue_level.loc[synonymous_mask, metric] = float("nan")
         residue_level = residue_level.drop(columns=["type"])
     residue_level = residue_level.groupby(STRUCT_COLS, as_index=False).agg(

--- a/src/metrics/sequence.py
+++ b/src/metrics/sequence.py
@@ -142,7 +142,7 @@ def calculate_avg_effect_quartiles(context: Context, percentiles: Optional[List[
     return pos_scores
 
 
-@register_metric(name='effect_variance', provides=['effect_variance', 'effect_variance_rank'], tags={'sequence'})
+@register_metric(name='effect_variance', provides=['effect_variance', 'effect_variance_rank'], tags={'sequence'}, requires={'resm'})
 def calculate_effect_variance(context: Context) -> pd.DataFrame:
     """
     Calculate the standard error of the mean for the effect scores at each position.
@@ -184,7 +184,7 @@ def calculate_effect_variance(context: Context) -> pd.DataFrame:
     return effect_variance
 
 
-@register_metric(name='effect_ranking', provides=['effect', 'effect_ranking'], tags={'sequence'})
+@register_metric(name='effect_ranking', provides=['effect', 'effect_ranking'], tags={'sequence'}, requires={'resm'})
 def calculate_effect_ranking(context: Context) -> pd.DataFrame:
     """
     Calculate the ranking of the effects.

--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -17,7 +17,6 @@ import src.metrics.bonds  # noqa: F401
 import src.metrics.sequence  # noqa: F401
 import src.metrics.structure  # noqa: F401
 from src.databases import pdbtm
-from src.metrics.averaging_metrics import METRICS_TO_AVERAGE
 from src.metrics.graph_metrics import calculate_graph_metrics
 from src.metrics.registry import _REGISTRY, metrics_with_tag
 from src.pipeline.context import Config, Context
@@ -548,7 +547,6 @@ class Runner:
         secondary_structure_features = calculate_secondary_structure_features(
             self.context,
             self.features,
-            ss_metrics=METRICS_TO_AVERAGE,
         )
         self.features = pd.merge(
             self.features,

--- a/src/pipeline/secondary_structure_features.py
+++ b/src/pipeline/secondary_structure_features.py
@@ -1,41 +1,33 @@
-from typing import List, Optional
-
 import pandas as pd
 
-from src.metrics.averaging_metrics import METRICS_TO_AVERAGE
+from src.metrics.averaging_metrics import (
+    assert_poolable_numeric_columns,
+    column_needs_synonym_mask,
+    spatial_pool_metric_columns,
+)
 from src.metrics.secondary_structure import ss_domain_lengths, ss_domain_log2_aa_group_ratios
 from src.pipeline.context import Context
-
-NONSYN_DOMAIN_COLUMNS = {
-    "avg_effect",
-    "effect_variance",
-    "effect_variance_rank",
-    "effect",
-    "effect_ranking",
-}
 
 
 def calculate_secondary_structure_features(
     context: Context,
     features: pd.DataFrame,
-    ss_metrics: Optional[List[str]] = None,
 ) -> pd.DataFrame:
     """Aggregate residue-level features onto secondary-structure domains."""
-    metrics_to_avg = ss_metrics if ss_metrics is not None else METRICS_TO_AVERAGE
     merge_cols = ["chain", "resi_struct", "resn_struct"]
 
     rt_subset = context.residue_table[merge_cols + ["ss_domains"]].drop_duplicates(merge_cols)
     merged = pd.merge(features, rt_subset, on=merge_cols, how="left")
     merged = merged.dropna(subset=["ss_domains"])
 
-    # Exclude synonymous rows from calculations when mutation type context is present.
+    cols_to_avg = [column for column in spatial_pool_metric_columns(features) if column in merged.columns]
+    assert_poolable_numeric_columns(cols_to_avg, merged)
+
     if "type" in merged.columns:
         synonymous_mask = merged["type"].eq("synonymous")
-        for column in NONSYN_DOMAIN_COLUMNS:
-            if column in merged.columns:
+        for column in cols_to_avg:
+            if column_needs_synonym_mask(column):
                 merged.loc[synonymous_mask, column] = float("nan")
-
-    cols_to_avg = [column for column in metrics_to_avg if column in merged.columns]
 
     residue_level_cols = merge_cols + ["ss_domains"] + cols_to_avg
     if cols_to_avg:

--- a/src/pipeline/sequence_window_features.py
+++ b/src/pipeline/sequence_window_features.py
@@ -5,16 +5,10 @@ from typing import Iterable
 import pandas as pd
 from pandas.api.types import is_bool_dtype, is_numeric_dtype
 
+from src.metrics.averaging_metrics import column_needs_synonym_mask, spatial_pool_metric_columns
 from src.pipeline.context import Context
 
 SEQUENCE_MERGE_COLS = ["chain", "resi_mut", "resn_mut"]
-NONSYN_WINDOW_COLUMNS = {
-    "avg_effect",
-    "effect_variance",
-    "effect_variance_rank",
-    "effect",
-    "effect_ranking",
-}
 
 
 def calculate_sequence_window_features(
@@ -24,6 +18,9 @@ def calculate_sequence_window_features(
     window_size: int = 5,
 ) -> pd.DataFrame:
     """Average numeric sequence-derived features across a centered sequence window.
+
+    Only columns both sequence-tagged and in ``spatial_pool_metric_columns(features)``
+    (neighbor / SS-domain pooling eligibility) enter the rolling step.
 
     Parameters
     ----------
@@ -53,18 +50,20 @@ def calculate_sequence_window_features(
     numeric sequence metric value.
     """
     seq_metric_columns = list(dict.fromkeys(seq_metric_columns))
-    # Limit the rolling step to realized numeric sequence metrics and skip labels.
+    eligible = set(spatial_pool_metric_columns(features))
+    # Numeric sequence outputs that are also spatial-pooling-eligible; skip labels/bool.
     numeric_cols = [
         column
         for column in seq_metric_columns
         if column in features.columns
+        and column in eligible
         and is_numeric_dtype(features[column])
         and not is_bool_dtype(features[column])
     ]
     if not numeric_cols:
         return pd.DataFrame(columns=SEQUENCE_MERGE_COLS)
 
-    # Align sequence metrics to a unique residue ordering before collapsing mutation rows.
+    # Order rows by aligned sequence position within each chain.
     align_pos = (
         context.residue_table[SEQUENCE_MERGE_COLS + ["align_pos"]]
         .drop_duplicates(SEQUENCE_MERGE_COLS)
@@ -78,26 +77,26 @@ def calculate_sequence_window_features(
         how="left",
         validate="many_to_one",
     )
-    # Exclude synonymous rows from calculations when mutation type context is present.
+    # Mutation-derived metrics: nan out synonymous rows before averaging across variants.
     if "type" in mutation_level.columns:
         synonymous_mask = mutation_level["type"].eq("synonymous")
         for column in numeric_cols:
-            if column in NONSYN_WINDOW_COLUMNS:
+            if column_needs_synonym_mask(column):
                 mutation_level.loc[synonymous_mask, column] = float("nan")
         mutation_level = mutation_level.drop(columns=["type"])
-    # Residue-level inputs for the window come from the mean across mutation rows.
+    # One residue-level value per (chain, resi_mut, resn_mut, align_pos): mean across resm variants.
     residue_level = mutation_level.groupby(
         SEQUENCE_MERGE_COLS + ["align_pos"],
         as_index=False,
     ).agg({column: "mean" for column in numeric_cols})
 
-    # Exclude residues with no numeric sequence metrics from the rolling series.
+    # Omit residues that have no numeric sequence metric left after synonym handling.
     residue_level = residue_level.loc[residue_level[numeric_cols].notna().any(axis=1), :]
     if residue_level.empty:
         return pd.DataFrame(columns=SEQUENCE_MERGE_COLS)
 
-    # Apply the centered rolling mean independently within each chain.
     residue_level = residue_level.sort_values(["chain", "align_pos"], kind="mergesort").reset_index(drop=True)
+    # Centered window along alignment order within each chain.
     for column in numeric_cols:
         residue_level[f"sequence_window_{column}"] = (
             residue_level.groupby("chain")[column]

--- a/tests/pipeline/test_neighbors.py
+++ b/tests/pipeline/test_neighbors.py
@@ -4,7 +4,10 @@ import warnings
 import pandas as pd
 import pytest
 
-from src.metrics.neighborhood_metrics import neighbor_sequence_range_metrics
+from src.metrics.neighborhood_metrics import (
+    average_neighbor_metrics,
+    neighbor_sequence_range_metrics,
+)
 from src.pipeline.neighbors import calculate_neighborhood_features, compute_residue_neighbors
 from src.pipeline.runner import Runner
 from src.structure.utils import res_key
@@ -142,6 +145,25 @@ def test_calculate_neighborhood_features_neighbor_averages_deterministic():
     assert result.loc[("A", 4, "SER"), "neighborhood_sasa"] == 6.0
 
     
+def test_average_neighbor_metrics_raises_on_non_numeric_pool_column():
+    """Non-numeric poolable columns raise at neighborhood averaging (guard for new metrics)."""
+
+    class DummyCtx:
+        extras = {"residue_neighbors": {}}
+
+    features = pd.DataFrame(
+        {
+            "chain": ["A"],
+            "resi_struct": [1],
+            "resn_struct": ["ALA"],
+            "sasa": [100.0],
+            "unvalidated_new_metric": ["not_numeric"],
+        }
+    )
+    with pytest.raises(ValueError, match="Neighborhood averaging requires poolable numeric"):
+        average_neighbor_metrics(DummyCtx(), features)
+
+
 def test_calculate_neighborhood_features_chain_neighbor_counts_deterministic():
     """Chain-aware neighbor counts separate same-chain from cross-chain neighbors."""
     class DummyContext:

--- a/tests/pipeline/test_secondary_structure_features.py
+++ b/tests/pipeline/test_secondary_structure_features.py
@@ -62,7 +62,7 @@ def test_calculate_secondary_structure_features_columns_exist(tmp_path):
     residue_table, features = _make_synthetic_ss_fixture()
     myrunner.context.residue_table = residue_table
 
-    out = calculate_secondary_structure_features(myrunner.context, features, ss_metrics=["metric_a"])
+    out = calculate_secondary_structure_features(myrunner.context, features)
 
     assert len(out) == len(residue_table)
     assert "ss_domains" in out.columns
@@ -94,7 +94,7 @@ def test_calculate_secondary_structure_features_na_in_metric(tmp_path):
     residue_table, features = _make_synthetic_ss_fixture(metric_with_nan=True)
     myrunner.context.residue_table = residue_table
 
-    out = calculate_secondary_structure_features(myrunner.context, features, ss_metrics=["metric_a"])
+    out = calculate_secondary_structure_features(myrunner.context, features)
     assert len(out) == len(residue_table)
     assert "ss_domain_metric_a" in out.columns
     assert "ss_domain_length" in out.columns
@@ -109,7 +109,7 @@ def test_calculate_secondary_structure_features_na_ss_domains_excluded(tmp_path)
     residue_table, features = _make_synthetic_ss_fixture(include_na_ss=True)
     myrunner.context.residue_table = residue_table
 
-    out = calculate_secondary_structure_features(myrunner.context, features, ss_metrics=["metric_a"])
+    out = calculate_secondary_structure_features(myrunner.context, features)
     assert len(out) == len(residue_table) - 1
     assert "ss_domains" in out.columns
     assert "ss_domain_length" in out.columns
@@ -128,7 +128,7 @@ def test_calculate_secondary_structure_features_averages_mutation_rows_per_resid
     features = pd.concat([features, dup_row], ignore_index=True)
 
     myrunner.context.residue_table = residue_table
-    out = calculate_secondary_structure_features(myrunner.context, features, ss_metrics=["metric_a"])
+    out = calculate_secondary_structure_features(myrunner.context, features)
     alpha = out[out["ss_domains"] == "alpha-helix_1"]
 
     assert np.isclose(alpha["ss_domain_metric_a"].iloc[0], 3.5)

--- a/tests/pipeline/test_sequence_window_features.py
+++ b/tests/pipeline/test_sequence_window_features.py
@@ -25,7 +25,6 @@ def test_calculate_sequence_window_features_collapses_and_rolls():
             "resn_mut": ["ALA", "ALA", "ARG", "ARG", "CYS", "CYS", "ASP", "ASP", "GLU", "GLU", "PHE", "PHE"],
             "effect": [2.0, 4.0, 4.0, 6.0, 6.0, 8.0, np.nan, np.nan, 10.0, 12.0, 12.0, 14.0],
             "blosum90": [1.0, 3.0, 2.0, 4.0, 3.0, 5.0, np.nan, np.nan, 5.0, 7.0, 6.0, 8.0],
-            "AA1_hydrophobicity_mut": [10.0, 14.0, 20.0, 24.0, 30.0, 34.0, np.nan, np.nan, 50.0, 54.0, 60.0, 64.0],
             "avg_effect_quartile": ["Q1", "Q1", "Q2", "Q2", "Q3", "Q3", None, None, "Q4", "Q4", "Q4", "Q4"],
             "mut_aa_group": ["A", "B", "A", "B", "A", "B", None, None, "A", "B", "A", "B"],
         }
@@ -37,7 +36,6 @@ def test_calculate_sequence_window_features_collapses_and_rolls():
         seq_metric_columns=[
             "effect",
             "blosum90",
-            "AA1_hydrophobicity_mut",
             "avg_effect_quartile",
             "mut_aa_group",
         ],
@@ -48,16 +46,11 @@ def test_calculate_sequence_window_features_collapses_and_rolls():
     assert ("A", 4, "ASP") not in result.index
     assert "sequence_window_avg_effect_quartile" not in result.columns
     assert "sequence_window_mut_aa_group" not in result.columns
-    assert "sequence_window_AA1_hydrophobicity_mut" in result.columns
 
     assert np.isclose(result.loc[("A", 1, "ALA"), "sequence_window_effect"], 5.0)
     assert np.isclose(result.loc[("A", 3, "CYS"), "sequence_window_effect"], 7.8)
     assert np.isclose(result.loc[("A", 5, "GLU"), "sequence_window_effect"], 9.0)
     assert np.isclose(result.loc[("A", 3, "CYS"), "sequence_window_blosum90"], 4.4)
-    assert np.isclose(
-        result.loc[("A", 3, "CYS"), "sequence_window_AA1_hydrophobicity_mut"],
-        36.0,
-    )
 
 
 def test_calculate_sequence_window_features_returns_empty_without_numeric_metrics():


### PR DESCRIPTION
## Goal

Unify neighbor, secondary-structure domain, and sequence-window pooling behind a single resolver that **excludes** metadata keys, mutation typing and category labels, amino-acid group categoricals, high-dimensional AAIndex/Kidera-style columns, and prefixed derived outputs. Add strict **numeric** validation for neighborhood averaging. Tie sequence-window inputs to the same pool-eligible set (hard cutover dropping rolls for columns that are not spatial-pool eligible).
Closes #135

## Implementation

- **`src/metrics/averaging_metrics.py`**: `spatial_pool_metric_columns()`, `METRICS_EXCLUDED_FROM_SPATIAL_POOLING`, synonym helpers (`column_needs_synonym_mask`, registry `resm` provides), `assert_poolable_numeric_columns`.
- **`src/metrics/neighborhood_metrics.py`**: use resolver + numeric guard; expanded synonym masking.
- **`src/pipeline/secondary_structure_features.py`**: removed `ss_metrics` override; resolver + numeric assert.
- **`src/pipeline/sequence_window_features.py`**: intersect sequence numerics with pool-eligible columns; synonym masking; docstring and inline comments clarified.
- **`src/pipeline/runner.py`**: dropped `METRICS_TO_AVERAGE` plumbing.
- **`src/metrics/sequence.py`**: `requires={'resm'}` on `effect_variance` and `effect_ranking`.
- **Tests**: SS tests two-arg API; sequence-window expectations without AAIndex rolling; neighbor test for non-numeric pool column error.

## Validation

Full `pytest` passed locally (170 tests).

## Other areas

None.

Made with [Cursor](https://cursor.com)