### PR TITLE
Remove count_ala_neighbors neighborhood metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,12 +370,6 @@ structure domain.  Additional domain-level columns:
 
 Amino acid groups: `Nonpolar_Aliphatic`, `Aromatic`, `Polar_Uncharged`, `Positively_Charged`, `Negatively_Charged`, `Special`.
 
-### Neighborhood metrics
-
-| Column | Description |
-|--------|-------------|
-| `n_ala_neighbors` | Number of alanine residues within the 5 Å neighbor shell |
-
 ### Ligand interaction metrics
 
 One column per detected ligand:

--- a/src/metrics/neighborhood_metrics.py
+++ b/src/metrics/neighborhood_metrics.py
@@ -25,52 +25,6 @@ from src.structure.utils import res_key
 STRUCT_COLS = ["chain", "resi_struct", "resn_struct"]
 
 
-def count_ala_neighbors(
-    context: Context,
-    features: pd.DataFrame,
-) -> pd.DataFrame:
-    """Number of alanine residues in the neighborhood of each residue.
-
-    Uses context.extras['residue_neighbors'] (residue_key -> [neighbor keys]).
-    For each residue, subsets features to neighbor rows and counts rows
-    with resn_struct == 'ALA'. Uses one row per (chain, resi_struct) when
-    looking up residue type so structure-level neighbors are counted once.
-
-    Parameters
-    ----------
-    context : Context
-        Context with extras['residue_neighbors'] mapping.
-    features : pd.DataFrame
-        Merged features from Runner (must have chain, resi_struct, resn_struct).
-    Returns
-    -------
-    pd.DataFrame
-        Columns: chain, resi_struct, resn_struct, n_ala_neighbors.
-    """
-    neighbor_map = context.extras["residue_neighbors"]
-
-    # One row per (chain, resi_struct, resn_struct) in features.
-    unique = features[STRUCT_COLS].drop_duplicates()
-    unique = unique.loc[unique.resi_struct.notna(), :]
-    
-    key_to_resn = dict(
-        zip(
-            (res_key(c, r, n) for c, r, n in zip(unique["chain"], unique["resi_struct"], unique["resn_struct"])),
-            unique["resn_struct"],
-        )
-    )
-
-    rows = []
-    for _, row in unique.iterrows():
-        chain, resi, resn = row["chain"], row["resi_struct"], row["resn_struct"]
-        residue_key = res_key(chain, resi, resn)
-        neighbor_keys = neighbor_map.get(residue_key, [])
-        n_ala = sum(1 for k in neighbor_keys if key_to_resn.get(k) == "ALA")
-        rows.append({"chain": chain, "resi_struct": resi, "resn_struct": resn, "n_ala_neighbors": n_ala})
-
-    return pd.DataFrame(rows)
-
-
 def count_chain_neighbors(
     context: Context,
     features: pd.DataFrame,
@@ -481,7 +435,6 @@ def neighbor_secondary_structure_coarse_granular_metrics(
 
 
 NEIGHBORHOOD_METRIC_FUNCTIONS = [
-    count_ala_neighbors,
     count_chain_neighbors,
     average_neighbor_metrics,
     neighbor_entropy_metrics,

--- a/tests/pipeline/test_neighbors.py
+++ b/tests/pipeline/test_neighbors.py
@@ -70,7 +70,6 @@ def test_calculate_neighborhood_features_basic(tmp_path):
 
     merge_cols = ["chain", "resi_struct", "resn_struct"]
     assert all(column in result.columns for column in merge_cols)
-    assert "n_ala_neighbors" in result.columns
     assert "neighborhood_sasa" in result.columns
     assert "neighbor_prop_alpha_helix" in result.columns
     assert "secondary_structure_coarse_entropy" in result.columns
@@ -101,7 +100,6 @@ def test_calculate_neighborhood_features_aggregates_multiple_metrics(tmp_path):
 
     merge_cols = ["chain", "resi_struct", "resn_struct"]
     assert all(column in result.columns for column in merge_cols)
-    assert "n_ala_neighbors" in result.columns
     assert "neighborhood_sasa" in result.columns
     assert "neighborhood_kyte_doolittle" in result.columns
     assert "neighbor_prop_alpha_helix" in result.columns

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -786,7 +786,7 @@ def test_run_neighborhood_requires_run_first(tmp_path):
 
 
 def test_run_neighborhood_fills_extras_and_merges(tmp_path):
-    """run_neighborhood fills context.extras['residue_neighbors'] and merges n_ala_neighbors into self.features."""
+    """run_neighborhood fills context.extras['residue_neighbors'] and merges neighborhood columns into self.features."""
     config_path = tmp_path / 'config.toml'
     _make_config_file(config_path)
 
@@ -804,11 +804,10 @@ def test_run_neighborhood_fills_extras_and_merges(tmp_path):
         assert isinstance(neighbors, list)
         assert residue_key not in neighbors, "neighbors must not include self"
 
-    # n_ala_neighbors from count_ala_neighbors is merged into self.features
-    assert 'n_ala_neighbors' in myrunner.features.columns
+    assert 'n_same_chain_neighbors' in myrunner.features.columns
     assert 'neighborhood_sasa' in myrunner.features.columns
     assert 'neighborhood_kyte_doolittle' in myrunner.features.columns
-    assert myrunner.features['n_ala_neighbors'].shape[0] == myrunner.features.shape[0]
+    assert myrunner.features['n_same_chain_neighbors'].shape[0] == myrunner.features.shape[0]
 
 
 def test_runner_save_results(tmp_path):


### PR DESCRIPTION
## Goal

Remove the `count_ala_neighbors` neighborhood metric so the pipeline no longer emits an `n_ala_neighbors` column.

## Implementation

- Deleted `count_ala_neighbors` from `src/metrics/neighborhood_metrics.py` and dropped it from `NEIGHBORHOOD_METRIC_FUNCTIONS`.
- Adjusted `tests/pipeline/test_neighbors.py` and `tests/pipeline/test_runner.py` so integration tests still validate neighborhood merges using other columns (e.g. `n_same_chain_neighbors`, pooled `neighborhood_*` metrics).
- Removed the lone README table row that documented `n_ala_neighbors`.

## Other areas

None.

Made with [Cursor](https://cursor.com)