### PR TITLE
Fix CI matrix failures on Python 3.12/3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Stephanie Wankowicz, Noah Greenwald"}]
 dependencies = [
-  "biotite",
+  "biotite>=1.0,<1.7",
   "biopython",   
   "numpy>=1.24",
   "pandas>=2.0",

--- a/src/structure/secondary_structure.py
+++ b/src/structure/secondary_structure.py
@@ -1,4 +1,3 @@
-import logging
 import subprocess
 from itertools import groupby
 from pathlib import Path
@@ -12,11 +11,6 @@ from biotite.structure.io.pdb import PDBFile
 
 from src.pipeline.context import Context
 from src.structure.utils import get_metadata_cols
-
-logger = logging.getLogger(__name__)
-
-# Fall back to pydssp before CI runners OOM-kill a hung mkdssp subprocess.
-MKDSSP_TIMEOUT_S = 30
 
 
 def make_contiguous_group_labels(lst: List[str]) -> List[str]:
@@ -66,14 +60,8 @@ def get_secondary_structure_annotations(context: Context) -> pd.DataFrame:
     """
     backend = context.extras.get("ss_backend", "pydssp")
     if backend == "mkdssp":
-        try:
-            ss_df, dssp_df = _annotate_with_mkdssp(context)
-            context.extras["dssp_output"] = dssp_df
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-            logger.warning("mkdssp failed (%s); falling back to pydssp", exc)
-            context.extras["ss_backend"] = "pydssp"
-            ss_df = _annotate_with_pydssp(context)
-            context.extras.pop("dssp_output", None)
+        ss_df, dssp_df = _annotate_with_mkdssp(context)
+        context.extras["dssp_output"] = dssp_df
     elif backend == "pydssp":
         ss_df = _annotate_with_pydssp(context)
         context.extras.pop("dssp_output", None)
@@ -131,10 +119,7 @@ def _write_temp_pdb(context: Context) -> Path:
     return pdb_path
 
 
-def _annotate_with_mkdssp(
-    context: Context,
-    timeout: float = MKDSSP_TIMEOUT_S,
-) -> tuple[pd.DataFrame, pd.DataFrame]:
+def _annotate_with_mkdssp(context: Context) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Run mkdssp and return normalized SSE annotations plus full DSSP fields."""
     pdb_path = _write_temp_pdb(context)
     dssp_tmp = NamedTemporaryFile(delete=False, suffix=".dssp")
@@ -143,7 +128,7 @@ def _annotate_with_mkdssp(
     rows: list[dict[str, Any]] = []
     try:
         cmd = ["mkdssp", str(pdb_path), str(dssp_path)]
-        subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=timeout)
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
 
         in_table = False
         for line in dssp_path.read_text(encoding="utf-8", errors="replace").splitlines():

--- a/src/structure/secondary_structure.py
+++ b/src/structure/secondary_structure.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 from itertools import groupby
 from pathlib import Path
@@ -11,6 +12,11 @@ from biotite.structure.io.pdb import PDBFile
 
 from src.pipeline.context import Context
 from src.structure.utils import get_metadata_cols
+
+logger = logging.getLogger(__name__)
+
+# Fall back to pydssp before CI runners OOM-kill a hung mkdssp subprocess.
+MKDSSP_TIMEOUT_S = 30
 
 
 def make_contiguous_group_labels(lst: List[str]) -> List[str]:
@@ -60,8 +66,14 @@ def get_secondary_structure_annotations(context: Context) -> pd.DataFrame:
     """
     backend = context.extras.get("ss_backend", "pydssp")
     if backend == "mkdssp":
-        ss_df, dssp_df = _annotate_with_mkdssp(context)
-        context.extras["dssp_output"] = dssp_df
+        try:
+            ss_df, dssp_df = _annotate_with_mkdssp(context)
+            context.extras["dssp_output"] = dssp_df
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            logger.warning("mkdssp failed (%s); falling back to pydssp", exc)
+            context.extras["ss_backend"] = "pydssp"
+            ss_df = _annotate_with_pydssp(context)
+            context.extras.pop("dssp_output", None)
     elif backend == "pydssp":
         ss_df = _annotate_with_pydssp(context)
         context.extras.pop("dssp_output", None)
@@ -119,7 +131,10 @@ def _write_temp_pdb(context: Context) -> Path:
     return pdb_path
 
 
-def _annotate_with_mkdssp(context: Context) -> tuple[pd.DataFrame, pd.DataFrame]:
+def _annotate_with_mkdssp(
+    context: Context,
+    timeout: float = MKDSSP_TIMEOUT_S,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Run mkdssp and return normalized SSE annotations plus full DSSP fields."""
     pdb_path = _write_temp_pdb(context)
     dssp_tmp = NamedTemporaryFile(delete=False, suffix=".dssp")
@@ -128,7 +143,7 @@ def _annotate_with_mkdssp(context: Context) -> tuple[pd.DataFrame, pd.DataFrame]
     rows: list[dict[str, Any]] = []
     try:
         cmd = ["mkdssp", str(pdb_path), str(dssp_path)]
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=timeout)
 
         in_table = False
         for line in dssp_path.read_text(encoding="utf-8", errors="replace").splitlines():

--- a/tests/pipeline/test_ligands.py
+++ b/tests/pipeline/test_ligands.py
@@ -1,13 +1,14 @@
 import biotite.structure as struc
 import numpy as np
 import pandas as pd
+import tomli
 
+from src.pipeline.context import Config, Context
 from src.pipeline.ligands import (
     calculate_protein_ligand_interactions,
     find_ligands,
     format_ligand_id,
 )
-from src.pipeline.runner import Runner
 from src.structure.structure_context import load_structure
 from tests.test_utils import _make_atoms, _make_config_file, _make_residue, _write_mmcif_file
 
@@ -66,21 +67,23 @@ def test_calculate_protein_ligand_interactions(tmp_path):
 
     config_path = tmp_path / "config_ligand.toml"
     _make_config_file(config_path, pdb_id="test")
+    with config_path.open("rb") as f:
+        config = Config(**tomli.load(f))
+    config.pdb_path = mmcif_path
 
-    myrunner = Runner(
-        pdb_id="test",
-        pdb_path=mmcif_path,
-        name="test_ligand",
-        config_path=config_path,
-    )
-
-    arr = myrunner.context.array
+    arr = load_structure(path=mmcif_path, pdb_id="test")
     if "hetero" not in arr.get_annotation_categories():
         hetero = np.zeros(arr.array_length(), dtype=bool)
         hetero[arr.chain_id == "B"] = True
         arr.set_annotation("hetero", hetero)
     else:
         arr.hetero[arr.chain_id == "B"] = True
+
+    context = Context(array=arr, config=config)
+    context.residue_table.rename(
+        columns={"resn": "resn_struct", "resi": "resi_struct"},
+        inplace=True,
+    )
 
     contacting_df = pd.DataFrame({
         "chain": ["A"],
@@ -89,15 +92,15 @@ def test_calculate_protein_ligand_interactions(tmp_path):
         "partner_residue_key": ["B:1:ALA"],
     })
 
-    result = calculate_protein_ligand_interactions(myrunner.context, contacting_df)
+    result = calculate_protein_ligand_interactions(context, contacting_df)
 
     assert "ligand_B_1_ALA_interactions" in result.columns
-    assert result.shape[0] == myrunner.context.residue_table.shape[0]
+    assert result.shape[0] == context.residue_table.shape[0]
     vals = result["ligand_B_1_ALA_interactions"].dropna().unique()
     assert len(vals) >= 1
     assert set(vals).issubset({"contact", "binding site", "second shell"})
 
     arr.hetero[:] = False
-    out_skip = calculate_protein_ligand_interactions(myrunner.context, contacting_df)
-    assert out_skip.shape[0] == myrunner.context.residue_table.shape[0]
+    out_skip = calculate_protein_ligand_interactions(context, contacting_df)
+    assert out_skip.shape[0] == context.residue_table.shape[0]
     assert "ligand_B_1_ALA_interactions" not in out_skip.columns


### PR DESCRIPTION
## Goal

Resolve GitHub Actions failures on Python 3.12/3.13 (exit 143 during `test_calculate_protein_ligand_interactions` while mkdssp runs in `Runner` init). This PR applies candidate fixes **one commit at a time** so CI can confirm which change works.

## Fix queue (in order)

1. **This commit:** mkdssp subprocess timeout (30s) with pydssp fallback in `get_secondary_structure_annotations`
2. If still failing: refactor `test_calculate_protein_ligand_interactions` to build `Context` directly (skip `Runner`/mkdssp)
3. If still failing: pin `biotite<1.7` in `pyproject.toml`

## Test plan

- [ ] All three matrix jobs (3.11, 3.12, 3.13) pass on fix 1
- [ ] If not, push fix 2 and re-check
- [ ] If not, push fix 3 and re-check


Made with [Cursor](https://cursor.com)