### PR TITLE
Add explain-diff skill for scientific HTML walkthroughs

### DIFF
--- a/.agents/skills/explain-diff/SKILL.md
+++ b/.agents/skills/explain-diff/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: explain-diff
+description: >-
+  Produce a self-contained HTML teaching page that explains a code change,
+  diff, branch, or pull request in terms of both software behavior and
+  scientific meaning (entity identity, identifiers and coordinates,
+  missingness, joins, downstream interpretation). Use when the user asks
+  for an HTML explanation, teaching walkthrough, or scientific explanation
+  of a diff, PR, or branch. Do not use for a short verbal summary or a
+  normal code review.
+---
+
+# Explain a code change
+
+## Goal
+
+One HTML page that builds this mental model:
+
+question → source data → representation → algorithm → output → downstream interpretation
+
+Scientific meaning is part of the software contract. Do not only list changed functions.
+
+## Load project domain
+
+Before exploring the diff, read project scientific context if it exists:
+
+1. `{workspace}/.agents/skills/explain-diff/domain.md`
+2. `domain.md` next to this `SKILL.md` (when installed as a project skill)
+
+If both exist and differ, prefer the workspace copy. If neither exists, infer from README, tests, examples, and the diff. Do not assume sequence, structure, imaging, or any other modality.
+
+## Principles
+
+1. For each important change, answer **what the code does** and **what scientific operation or assumption that behavior represents**. Do not stop at “this function left-joins on an ID column”: say what those keys represent, whether both sides use the same scheme, why the join is appropriate, what unmatched rows mean, and how a wrong join would affect downstream results.
+2. Implementation correctness ≠ scientific correctness. Tests, types, and green CI do not establish that identifiers, coordinates, units, or filters are scientifically right.
+3. Separate **evidence** (code, tests, schemas, config, docs, fixtures) from **interpretation**. Never invent a scientific rationale. If an assumption cannot be verified locally, say so.
+4. Trace scientifically meaningful fields from source through transforms to downstream use — only for fields the change actually touches.
+5. Ask: could this change which observations are included, how they are represented, the numbers computed, or the conclusion drawn downstream? Watch for non-random dropping (selection effects).
+
+### Question types (only when implicated)
+
+Not a checklist to fill:
+
+- What experimental or biological entity does each object represent? Does the change treat two entities as equivalent?
+- Which identifier or coordinate systems are in play, and are they being mixed?
+- What is the unit of observation, and can a join, filter, group-by, or reshape drop, duplicate, merge, reorder, or reassign it?
+- What do missing, zero, NaN, None, and empty mean here? They are not equivalent unless the code says so.
+- Which units, scales, or transforms apply?
+- Does the result depend on a pinned reference, database, or tool version?
+
+If identifiers, coordinates, or indices are transformed, diagram that mapping explicitly. Do not let the reader infer equivalence from variable names.
+
+## Workflow
+
+1. **Resolve the target.** Current checkout, uncommitted diff, `main...HEAD` / `origin/main...HEAD`, a PR, or a user-specified range. If ambiguous, infer and state the assumption in the page.
+2. **Read the surrounding system**, not the hunk list: domain file, callers/callees, schemas, tests, examples, config. Prefer those over speculation. Do not run the full pipeline unless needed to explain a numerical change.
+3. **Build the model, then write HTML:** scientific problem; old behavior; why it changed; new behavior; data in; transforms; assumptions; how correctness is checked; downstream effect.
+
+Only discuss assumptions the change implicates.
+
+## Page structure
+
+Always include: title, one-paragraph summary, linked TOC, then:
+
+1. **What changed and why** — scientific and software
+2. **How it works** — algorithm and data flow with a toy or fixture example (label invented values as toy)
+3. **Scientific impact** — before/after; which of observations / representation / numbers / conclusions actually moved; selection effects if rows drop
+4. **Code walkthrough** — grouped by conceptual operation, not file order; tiny excerpts with `path:line`; distinguish infrastructure-only edits from scientifically consequential ones
+
+Include only when relevant:
+
+- Identifier/coordinate mapping diagram
+- Assumptions vs invariants (where enforced or tested, if known)
+- Validation, plus the most dangerous *silent* scientific failure (plausible-looking output, wrong interpretation)
+- Realistic edge cases
+- Quiz: 3–5 conceptual multiple-choice questions with plausible distractors and an explanation after selection. Skip for purely infrastructural diffs. Do not test filenames.
+
+## Where to save
+
+Default directory: `/tmp`. Filename: `YYYY-MM-DD-explanation-<slug>.html` (today’s date, short kebab-case slug).
+
+Example: `/tmp/2026-08-14-explanation-residue-mapping.html`
+
+If the user names a different directory or full path, use that instead. Create the directory if needed. Do not write inside the repository unless they explicitly ask to.
+
+## HTML artifact
+
+- One self-contained file: inline CSS and JS, no CDN, no network, no external fonts or images
+- `pre, code { white-space: pre-wrap; }` so newlines survive
+- Escape repository-derived text before inserting into HTML or JS
+- Semantic HTML/CSS diagrams; no ASCII art
+- Do **not** modify repository files (except when the user asked to save the HTML there)
+- Do **not** use a Cursor canvas
+
+Before handoff, confirm the file exists, opens offline, TOC links work, code blocks keep whitespace, and quiz clicks work if a quiz is present.
+
+## Handoff
+
+Return a `file://` link to the HTML. Then 3–4 sentences: what change was inspected, what surrounding pipeline was inspected, unverified assumptions, validation limits. The page holds the full explanation.
+
+## Anti-patterns
+
+- File-by-file diff narration or dumping the full diff
+- Filling scientific categories that the change does not implicate
+- Claiming scientific correctness because tests pass
+- Inventing biology or experimental rationale
+- Assuming a modality (sequence, structure, imaging, …) when `domain.md` is absent

--- a/.agents/skills/explain-diff/domain.md
+++ b/.agents/skills/explain-diff/domain.md
@@ -1,0 +1,65 @@
+# Domain contract (this repository)
+
+Computes per-residue structural and sequence metrics from a PDB/mmCIF structure, optionally joined to deep mutational scanning (DMS) data as one row per mutation.
+
+Canonical schemas and column lists: [README.md](../../../README.md). Worked examples and fixtures: `examples/`, `tests/`. Do not restate those dictionaries here.
+
+## Objects
+
+- **Structure**: one PDB ID (RCSB) or local PDB/mmCIF; one or more chains. `structural_feature_chains` may restrict which chains get metrics.
+- **Experimental / DMS WT sequence**: reconstructed from the mutation table’s wildtype letters at `position`; aligned to `mutation_data_chain`.
+- **Mutation**: one input row per mutation (`position`, `wildtype`, `mutation`, `type`, `effect`).
+- **Membrane vs soluble**: `membrane_protein` fetches PDBTM, orients the structure, and enables membrane-frame metrics.
+
+Do not assume the deposited structure and the assay construct are the same isoform, numbering, or length — alignment exists because they often differ.
+
+## Identifiers and numbering
+
+These are different systems. Equal integers are not the same residue without a documented mapping.
+
+| System | Where it lives | Notes |
+| --- | --- | --- |
+| Chain ID | PDB `chain` | DMS alignment uses `mutation_data_chain` only |
+| `resi_mut` / input `position` | experimental WT numbering | Not PDB numbering |
+| `resi_struct` | Biotite `AtomArray.res_id` | Typically PDB author residue numbers, not mmCIF `label_seq_id` |
+| `align_pos` | pairwise alignment column | 0-based; a gap is NaN on one side |
+| `resn_mut` / `resn_struct` | 3-letter residue names | A letter mismatch after mapping is a scientific event, not a join bug |
+
+Insertion codes exist in mmCIF (`pdbx_PDB_ins_code`) but output tables key residues by `(chain, resi_struct)`. Alternate locations: `altloc_policy` `"highest"` (default, one conformer) vs `"all"` (one row per conformer).
+
+If a change transforms positions, diagram:
+
+experimental `position` → alignment column (`align_pos`) → `resi_struct` on `mutation_data_chain`
+
+## Cardinality
+
+- Structure-only features: **one row per residue** (or per residue×altloc if `"all"`).
+- DMS-mode features: **one row per mutation**.
+- Metadata: residue-level; `struct_info` / `mut_info` mark which side is present.
+- Alignment gaps: NaN on the missing side. Mutations without a structural partner should keep the experimental row and leave structural features missing — not a shifted mapping.
+
+Joins on `(chain, resi_struct)` or `(resi_mut, resn_mut)` can drop, duplicate, or silently realign rows if keys are non-unique (insertion codes, altlocs, duplicate mutation positions).
+
+## Missingness
+
+Do not equate `NaN`, `None`, `0`, and “not in the structure.”
+
+Typical meanings here: residue unresolved or absent from the chain; terminal vs internal alignment gap; mutation with no structural partner; metric not computed (wrong mode, missing DSSP, non-membrane run); hydrogens or altlocs stripped.
+
+## Units and versions
+
+- Distances and SASA: Å / Å². `membrane_thickness` is half-thickness in Å.
+- Secondary structure: `mkdssp` if on `PATH`, else `pydssp` — engine can change SS labels.
+- Structure source: RCSB `pdb_id` vs local `pdb_path`; the assembly/version is whatever file was loaded.
+- Sequence features: checked-in AAIndex / Kidera tables under `data/`.
+
+## Silent failures (check when implicated)
+
+- Joining mutation `position` to `resi_struct` without going through the alignment.
+- Mixing mmCIF `label_seq_id` with author `res_id`.
+- Two residues sharing `resi_struct` (insertion code) collapsed to one row.
+- `altloc_policy` changing row counts or occupancy-weighted metrics.
+- Alignment gaps shifting which mutation inherits which structural features.
+- `resn_mut` ≠ `resn_struct` after mapping and being ignored.
+- Membrane metrics without PDBTM orientation, or the reverse.
+- Terminal gaps excluded from alignment-quality scoring but still present in the merged table.


### PR DESCRIPTION
## Goal

Give agents a reusable way to explain a diff, branch, or pull request as a self-contained HTML teaching page that covers both software behavior and scientific meaning.

## Implementation

Add `.agents/skills/explain-diff/SKILL.md` with the generic workflow: scientific-contract principles, adaptive page structure, quiz when useful, and a default save path under `/tmp`. Add `.agents/skills/explain-diff/domain.md` with this repository’s structure/DMS objects, numbering systems, join cardinality, and known silent failures. Copy the skill to another project by replacing only `domain.md`.

## Other areas

None.

## Test plan

- [x] Ruff on `src` and `tests`
- [x] Full `pytest tests/` locally (252 passed)
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)